### PR TITLE
Hotfix/broken compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ csl_very_large_object_test_copy.csl
 builddir
 subprojects/SDL2-2.0.12/
 subprojects/packagecache/
+subprojects/googletest-release-*
 callgrind*
 massif.out*
 .vim_session

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Originally it was an ongoing project in 2015-16, but it is stagnated and now is 
 
 ## Installation
 
-### Before compiling: Dependencies
-
-Since for testing, the `googltest` framework is used, the corresponding package has to be installed in order for the project to compile.
-
 ### Before running: Cloning the assets
 
 Since the assets needed to run the example programs are quite large, they are located

--- a/meson.build
+++ b/meson.build
@@ -62,8 +62,10 @@ endif
 
 # Unit tests
 
-gtest_proj = subproject('gtest')
-gtest_dep = dependency('gtest_main')
+if not meson.is_cross_build()
+    gtest_proj = subproject('gtest')
+    gtest_dep = dependency('gtest_main')
 
-test_executable = executable('testprog', 'test/example.cpp', dependencies : gtest_dep)
-test('gtest test', test_executable)
+    test_executable = executable('testprog', 'test/example.cpp', dependencies : gtest_dep)
+    test('gtest test', test_executable)
+endif

--- a/meson.build
+++ b/meson.build
@@ -60,17 +60,10 @@ else
 endif
 
 
-#gtest_proj = subproject('gtest')
-#gtest_dep = gtest_proj.get_variable('gtest_dep')
-#gtest_dep = dependency('gtest', main: true)
-#gmock_dep = gtest_proj.get_variable('gmock_dep')
+# Unit tests
 
-#test_src = ['test/example.cpp', 'tests/gtest_all.cc']
+gtest_proj = subproject('gtest')
+gtest_dep = dependency('gtest_main')
 
-#e = executable('gtest-all', test_src, dependencies : [gtest_dep, gmock_dep,oe_dep])
-
-#test('gtest tests', e)
-
-gtest_dep = dependency('gtest', main : true)
-e = executable('testprog', 'test/example.cpp', dependencies : gtest_dep)
-test('gtest test', e)
+test_executable = executable('testprog', 'test/example.cpp', dependencies : gtest_dep)
+test('gtest test', test_executable)

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = googletest-release-1.11.0
+source_url = https://github.com/google/googletest/archive/release-1.11.0.tar.gz
+source_filename = gtest-1.11.0.tar.gz
+source_hash = b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
+patch_filename = gtest_1.11.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.11.0-2/get_patch
+patch_hash = 764530d812ac161c9eab02a8cfaec67c871fcfc5548e29fd3d488070913d4e94
+
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep
+


### PR DESCRIPTION
Only compile tests when running meson natively; Meson automatically downloads `googletest` as a subproject, so it is no longer a system dependency