### PR TITLE
Tidy/refactoring optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | |____| |  | |_____    | |______  | |___| | | |______  | |___| |    |_|
 \________/  |_______|   |________| |_______| |________| |_______|     
 ```
-The Oxygen Engine (OE) is a hobbyist modular 3D game engine written in C++, in development for learning purposes.
+The Oxygen Engine (OE) is a hobbyist modular 3D game engine written in C++20, in development for learning purposes.
 
 It currently implements a custom file format with asynchronous loading (.csl), a multithreaded pipeline with game logic and renderer running in separate threads, an event handler and an OpenGL 3.3+/ES 2.0+ Renderer using SDL2, GLad and GLM.
 

--- a/examples/oe_main_test.cpp
+++ b/examples/oe_main_test.cpp
@@ -178,7 +178,7 @@ int OnLoadObject(oe::task load_event_task, string event_name){
 int main(){
     
     // everything in namespace oe::preinit needs to be run before oe::init() to take effect
-    oe::preinit::use_legacy_renderer = true;
+    oe::preinit::request_gles2();
 
     oe::init("Oxygen Engine Demo", 800, 480, false);
     //oe::pause(20);

--- a/examples/oe_main_test.cpp
+++ b/examples/oe_main_test.cpp
@@ -136,10 +136,9 @@ int test_task3(oe::task task){
     else {
     
     }
-    
+
     return task.CONTINUE();
 }
-
 
 int OnLoadObject(oe::task load_event_task, string event_name){
     cout << "SUCCESSFULLY loaded '" << event_name << "'" << endl;
@@ -159,7 +158,6 @@ int OnLoadObject(oe::task load_event_task, string event_name){
     oe::set_event_func("keyboard-d+", &update_monkey_rot_neg_z);
     
     oe::set_event_func("keyboard-space+", &toggle_mouse_locked_state);
-    
     // Useful for debugging
     oe::set_event_func("keyboard-f5+", &set_renderer_mode_normals);
     oe::set_event_func("keyboard-f6+", &renderer_toggle_bounding_spheres);
@@ -172,6 +170,7 @@ int OnLoadObject(oe::task load_event_task, string event_name){
     oe::add_task_func("test_task3", 4, &test_task3);
     oe::mouse_lock();
 
+    oe::set_window_title("Oxygen Engine - " + event_name);
     return 0;
 }
 

--- a/examples/oe_main_test.cpp
+++ b/examples/oe_main_test.cpp
@@ -60,10 +60,10 @@ int renderer_toggle_bounding_spheres( oe::task, string event_name){
 
 int set_renderer_mode_normals( oe::task, string event_name){
     
-    if (oe::get_shading_mode() == oe::renderer::shading_mode::regular)
-        oe::set_shading_mode(oe::renderer::shading_mode::normals);
+    if (oe::get_shading_mode() == oe::RENDERER_REGULAR_SHADING)
+        oe::set_shading_mode(oe::RENDERER_NORMALS_SHADING);
     else
-        oe::set_shading_mode(oe::renderer::shading_mode::regular);
+        oe::set_shading_mode(oe::RENDERER_REGULAR_SHADING);
     return 0;
 }
 

--- a/examples/oe_main_test.cpp
+++ b/examples/oe_main_test.cpp
@@ -140,6 +140,11 @@ int test_task3(oe::task task){
     return task.CONTINUE();
 }
 
+int toggle_debug_mode(oe::task task, string event_name){
+    oe::toggle_renderer_sanity_checks();
+    return 0;
+}
+
 int OnLoadObject(oe::task load_event_task, string event_name){
     cout << "SUCCESSFULLY loaded '" << event_name << "'" << endl;
     
@@ -163,6 +168,7 @@ int OnLoadObject(oe::task load_event_task, string event_name){
     oe::set_event_func("keyboard-f6+", &renderer_toggle_bounding_spheres);
     oe::set_event_func("keyboard-f7+", &renderer_toggle_wireframe);
     oe::set_event_func("keyboard-f8+", &renderer_toggle_bounding_boxes);
+    oe::set_event_func("keyboard-f9+", &toggle_debug_mode);
     
     oe::add_task_func("test_task1", &test_task1, "\"Camera\"");
     oe::add_task_func("test_task0", 2, &test_task0);

--- a/include/OE/Events/event.h
+++ b/include/OE/Events/event.h
@@ -26,7 +26,7 @@
  * Philsegeler's TODO:
  * -Anything else his subsystems need
  */
-namespace oe{
+namespace oe {
 
     enum event_type {
         CUSTOM_EVENT     = 0,
@@ -49,7 +49,7 @@ namespace oe{
         friend class input_event_handler_t;
 
     public:
-        //static bool finished;
+        // static bool finished;
         event_t();
         virtual ~event_t();
         virtual int call() = 0;
@@ -63,8 +63,8 @@ namespace oe{
         bool        active_{false};
         std::string name_;
 
-        event_type type_;
-        event_func_type  func_;
+        event_type      type_;
+        event_func_type func_;
 
         OE_Task task_;
 
@@ -151,5 +151,5 @@ namespace oe{
     protected:
     };
 
-};
+};     // namespace oe
 #endif // OE_EVENT_H

--- a/include/OE/Events/event.h
+++ b/include/OE/Events/event.h
@@ -7,7 +7,7 @@
 #include <functional>
 #include <memory>
 #include <set>
-
+#include <unordered_set>
 
 /** Temporary documentation: (OUTDATED)
  *
@@ -54,6 +54,9 @@ namespace oe {
         virtual ~event_t();
         virtual int call() = 0;
 
+        static std::atomic<std::size_t> current_id;
+        std::size_t                     id;
+
     protected:
         // internal_call() is implemented in OE_Error.cpp
         int internal_call();
@@ -68,8 +71,8 @@ namespace oe {
 
         OE_Task task_;
 
-        bool                  has_init_{false};
-        std::set<std::string> sub_events_;
+        bool                            has_init_{false};
+        std::unordered_set<std::size_t> sub_events_;
     };
 
     /*button event used in keyboard/mouse/gamepad*/

--- a/include/OE/Events/event.h
+++ b/include/OE/Events/event.h
@@ -93,6 +93,7 @@ namespace oe {
     protected:
         uint8_t     keystate_;
         std::string key_;
+        bool        is_main_event_{false};
     };
 
     /// class intended to store mouse events (3 for each mouse buttons 1-5)
@@ -106,8 +107,8 @@ namespace oe {
         int call();
 
     protected:
-        uint8_t keystate_;
-
+        uint8_t     keystate_;
+        bool        is_main_event_{false};
         std::string key_;
     };
 

--- a/include/OE/Events/event.h
+++ b/include/OE/Events/event.h
@@ -11,7 +11,7 @@
 
 /** Temporary documentation: (OUTDATED)
  *
- * OE_Event::call(OE_Task*):
+ * event_t::call(OE_Task*):
  * Return values:
  *  0: successfully run
  *  1: event is executed in another thread
@@ -26,157 +26,130 @@
  * Philsegeler's TODO:
  * -Anything else his subsystems need
  */
-enum OE_EVENT_TYPE {
-    OE_CUSTOM_EVENT    = 0,
-    OE_KEYBOARD_EVENT  = 1,
-    OE_MOUSE_EVENT     = 2,
-    OE_GAMEPAD_EVENT   = 3,
-    OE_NETWORK_EVENT   = 4,
-    OE_COLLISION_EVENT = 5,
-    OE_ERROR_EVENT     = 6,
-    OE_EVENT_COMBO     = 7
+namespace oe{
+
+    enum event_type {
+        CUSTOM_EVENT     = 0,
+        KEYBOARD_EVENT   = 1,
+        MOUSE_EVENT      = 2,
+        GAMEPAD_EVENT    = 3,
+        NETWORK_EVENT    = 4,
+        COLLISION_EVENT  = 5,
+        MOUSE_MOVE_EVENT = 6,
+        EVENT_COMBO      = 7
+    };
+
+    int template_event_func(OE_Task, std::string);
+
+    typedef std::function<int(OE_Task, std::string)> event_func_type;
+
+    /* general event type */
+    class event_t : public OE_THREAD_SAFETY_OBJECT {
+        friend class event_handler_t;
+        friend class input_event_handler_t;
+
+    public:
+        //static bool finished;
+        event_t();
+        virtual ~event_t();
+        virtual int call() = 0;
+
+    protected:
+        // internal_call() is implemented in OE_Error.cpp
+        int internal_call();
+
+        void set_func(const event_func_type);
+
+        bool        active_{false};
+        std::string name_;
+
+        event_type type_;
+        event_func_type  func_;
+
+        OE_Task task_;
+
+        bool                  has_init_{false};
+        std::set<std::string> sub_events_;
+    };
+
+    /*button event used in keyboard/mouse/gamepad*/
+
+
+    enum button_type { BUTTON_RELEASE = 0, BUTTON_PRESS = 2, BUTTON_JUST_PRESS = 1, BUTTON_JUST_RELEASE = 3 };
+
+    /// class intended to store keyboard events (3 for each )
+    class keyboard_event_t : public event_t {
+        friend class event_handler_t;
+        friend class input_event_handler_t;
+
+    public:
+        keyboard_event_t();
+        ~keyboard_event_t();
+        int call();
+
+    protected:
+        uint8_t     keystate_;
+        std::string key_;
+    };
+
+    /// class intended to store mouse events (3 for each mouse buttons 1-5)
+    class mouse_event_t : public event_t {
+        friend class event_handler_t;
+        friend class input_event_handler_t;
+
+    public:
+        mouse_event_t();
+        ~mouse_event_t();
+        int call();
+
+    protected:
+        uint8_t keystate_;
+
+        std::string key_;
+    };
+
+    /// class intended to store mouse move events
+    class mouse_move_event_t : public event_t {
+        friend class event_handler_t;
+        friend class input_event_handler_t;
+
+    public:
+        mouse_move_event_t();
+        ~mouse_move_event_t();
+        int call();
+    };
+
+    /// class intended to store gamepad events (3 for each mouse buttons 1-5 and mouse position)
+    class gamepad_event_t : public event_t {
+        friend class event_handler_t;
+        friend class input_event_handler_t;
+
+    public:
+        gamepad_event_t();
+        ~gamepad_event_t();
+        int call();
+
+    protected:
+        uint8_t     keystate_;
+        std::string key_;
+
+        int  axis_;
+        bool axismoved_;
+        int  x_, y_, delta_x_, delta_y_;
+    };
+
+    /// class intended for user events
+    class custom_event_t : public event_t {
+        friend class event_handler_t;
+        friend class input_event_handler_t;
+
+    public:
+        custom_event_t();
+        ~custom_event_t();
+        int call();
+
+    protected:
+    };
+
 };
-
-enum OE_ERROR_IMPORTANCE { OE_WARNING = 0, OE_ERROR = 1, OE_FATAL = 2 };
-
-typedef std::function<int(OE_Task, std::string)> OE_EVENTFUNC;
-
-int template_event_func(OE_Task, std::string);
-
-/* general event type */
-class OE_Event : public OE_THREAD_SAFETY_OBJECT {
-    friend class OE_EventHandler;
-    friend class OE_InputEventHandler;
-
-public:
-    static bool finished;
-    OE_Event();
-    virtual ~OE_Event();
-    virtual int call() = 0;
-
-protected:
-    // internal_call() is implemented in OE_Error.cpp
-    int internal_call();
-
-    void setFunc(const OE_EVENTFUNC);
-
-    bool        active_{false};
-    std::string name_;
-
-    OE_EVENT_TYPE type_;
-    OE_EVENTFUNC  func_;
-
-    OE_Task task_;
-
-    bool                  has_init_{false};
-    std::set<std::string> sub_events_;
-};
-
-/*button event used in keyboard/mouse/gamepad*/
-
-
-enum OE_BUTTON { RELEASE = 0, PRESS = 2, JUST_PRESS = 1, JUST_RELEASE = 3 };
-
-/// class intended to store keyboard events (3 for each )
-class OE_KeyboardEvent : public OE_Event {
-    friend class OE_EventHandler;
-    friend class OE_InputEventHandler;
-
-public:
-    OE_KeyboardEvent();
-    ~OE_KeyboardEvent();
-    int call();
-
-protected:
-    uint8_t     keystate;
-    std::string key;
-};
-
-/// class intended to store mouse events (3 for each mouse buttons 1-5 and mouse position + mouse wheel)
-class OE_MouseEvent : public OE_Event {
-    friend class OE_EventHandler;
-    friend class OE_InputEventHandler;
-
-public:
-    OE_MouseEvent();
-    ~OE_MouseEvent();
-    int call();
-
-    static int  x, y, delta_x, delta_y, mouse_wheel;
-    static bool mousemoved;
-
-protected:
-    void signal();
-    void wait();
-
-    uint8_t keystate;
-
-    std::string key;
-};
-
-/// class intended to store gamepad events (3 for each mouse buttons 1-5 and mouse position)
-class OE_GamepadEvent : public OE_Event {
-    friend class OE_EventHandler;
-    friend class OE_InputEventHandler;
-
-public:
-    OE_GamepadEvent();
-    ~OE_GamepadEvent();
-    int call();
-
-protected:
-    uint8_t     keystate;
-    std::string key;
-
-    int  axis;
-    bool axismoved;
-    int  x, y, delta_x, delta_y;
-};
-
-/// class intended for user events
-class OE_CustomEvent : public OE_Event {
-    friend class OE_EventHandler;
-    friend class OE_InputEventHandler;
-
-public:
-    OE_CustomEvent();
-    ~OE_CustomEvent();
-    int call();
-
-protected:
-};
-
-/// class intended for error events
-class OE_ErrorEvent : public OE_Event {
-    friend class OE_EventHandler;
-    friend class OE_InputEventHandler;
-
-public:
-    OE_ErrorEvent();
-    ~OE_ErrorEvent();
-    int call();
-
-protected:
-    OE_ERROR_IMPORTANCE importance;
-    std::string         error_output;
-    std::string         error_name;
-};
-
-
-/// class intended to store multiple events
-/// TODO
-class OE_EventCombo : public OE_Event {
-    friend class OE_EventHandler;
-    friend class OE_InputEventHandler;
-
-public:
-    OE_EventCombo();
-    ~OE_EventCombo();
-    int call();
-
-protected:
-    std::vector<std::string> event_list;
-    OE_EventPair             indices;
-};
-
 #endif // OE_EVENT_H

--- a/include/OE/Events/event_container.h
+++ b/include/OE/Events/event_container.h
@@ -1,0 +1,510 @@
+#ifndef OE_EVENT_CONTAINER_H
+#define OE_EVENT_CONTAINER_H
+
+
+#include <OE/error_oe.h>
+#include <OE/types/base_types.h>
+#include <algorithm>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <set>
+
+
+
+/** New General class based on oe::shared_index_map_t intended to optimize and properly parallelize accesing of
+ * individual events. Stores ids and names. Only stores one name per element and one id per element.
+ * Supports input iterators. Everything apart from iterators is 100% thread-safe.
+ * The difference between this and oe::shared_index_map is that
+ *  - No pending elements, elements are added directly
+ *  - Registered is renamed to Registered and an event can come more than once
+ */
+
+namespace oe {
+    template <typename T>
+    class event_container_t : public OE_THREAD_SAFETY_OBJECT {
+    protected:
+        std::unordered_map<std::size_t, std::shared_ptr<T>> elements_;
+        std::set<std::string>                               names_;
+
+        void register_event(const std::size_t& index) {
+            lockMutex();
+            this->registered_.add(index);
+            unlockMutex();
+        }
+
+        void clear_internally() {
+
+            for (auto x : elements_) {
+                this->deleted_.add(x.first);
+            }
+            elements_.clear();
+            registered_.clear();
+
+            names_.clear();
+            id2name_.clear();
+        }
+
+    public:
+        std::unordered_map<std::size_t, std::string> id2name_;
+        OE_Name2ID                                   name2id;
+
+        friend class Registered;
+        friend class Element;
+
+        event_container_t() : registered_(*this), deleted_(*this) {
+            lockMutex();
+            this->name2id = OE_Name2ID(&this->id2name_);
+            unlockMutex();
+        };
+
+        event_container_t(const event_container_t&) = delete;
+
+        ~event_container_t() {
+        }
+
+        std::size_t size() {
+            lockMutex();
+            std::size_t output = this->elements_.size();
+            unlockMutex();
+            return output;
+        }
+
+        //*******************************************/
+        // interfacing class
+
+        class Element {
+        public:
+            Element() {
+            }
+            Element(event_container_t<T>* db, std::size_t index, std::shared_ptr<T> element)
+                : id_(index), p_(element), db_(db) {
+            }
+
+            std::size_t        id_{0};
+            std::shared_ptr<T> p_{nullptr};
+
+            void flag_as_registered() {
+                db_->register_event(this->id_);
+            }
+
+            bool is_valid() {
+                return p_ != nullptr;
+            }
+
+            std::string get_name() {
+                return db_->get_name(id_);
+            }
+
+        protected:
+            event_container_t<T>* db_;
+        };
+
+        //*******************************************/
+        // methods
+
+        void extend(event_container_t<T>& other, bool override_names) {
+            lockMutex();
+
+            other.synchronize(false);
+
+            if (!override_names) {
+                for (auto x : other) {
+                    this->appendUNSAFE(x.get_name(), x.p_);
+                }
+            }
+            else {
+                for (auto x : other) {
+                    this->force_appendUNSAFE(x.get_name(), x.p_);
+                }
+            }
+
+            unlockMutex();
+        }
+
+        // TODO: Add referemce count
+        int count(std::size_t index) {
+            int output = 0;
+            lockMutex();
+            if (this->elements_.count(index) == 1) {
+                output = 1;
+            }
+            unlockMutex();
+            return output;
+        }
+
+
+        // TODO: Add referemce count
+        int count(const std::string& name) {
+            int output = 0;
+            lockMutex();
+            if (this->names_.count(name) == 1) {
+                output = 1;
+            }
+            unlockMutex();
+            return output;
+        }
+
+        std::string get_name(const std::size_t& index) {
+            if (id2name_.count(index) != 0) return id2name_[index];
+            return "";
+        }
+
+        void append(const std::string& name, std::shared_ptr<T> element) {
+            lockMutex();
+            this->appendUNSAFE_now(name, element);
+            unlockMutex();
+        }
+
+        void appendUNSAFE(const std::string& name, std::shared_ptr<T> element) {
+            if ((this->count(element->id) == 0) && (this->pending_elements_.count(element->id) == 0)) {
+                this->elements_[element->id] = element;
+                this->id2name_[element->id]  = name;
+                this->names_.insert(name);
+            }
+            else {
+                OE_Warn("Element with ID: '" + std::to_string(element->id) + "' and name: '" + name +
+                        "' already exists in SharedIndexMap<" + typeid(T).name() + ">.");
+            }
+        }
+
+        void force_append(const std::string& name, std::shared_ptr<T> element) {
+            lockMutex();
+            this->force_appendUNSAFE_now(name, element);
+            unlockMutex();
+        }
+
+        void force_appendUNSAFE(const std::string& name, std::shared_ptr<T> element) {
+            if (names_.count(name) == 1) {
+                this->elements_.erase(this->name2id[name]);
+                this->id2name_.erase(this->name2id[name]);
+                registered_.remove(this->name2id[name]);
+                deleted_.add(this->name2id[name]);
+            }
+            this->elements_[element->id] = element;
+            this->id2name_[element->id]  = name;
+            this->registered_.add(element->id);
+        }
+
+        std::string to_str() {
+            lockMutex();
+            std::string output = "[\n";
+            for (auto x : elements_) {
+                output.append(id2name_[x.first] + " ; " + std::to_string(x.first));
+                output.append("\n");
+            }
+            output.append("]");
+            unlockMutex();
+            return output;
+        }
+
+        void reset_registered() {
+            lockMutex();
+            this->reset_registeredUNSAFE();
+            unlockMutex();
+        }
+
+        void reset_registeredUNSAFE() {
+            this->registered_.clear();
+        }
+
+        void synchronize(bool clear_all) noexcept {
+
+            lockMutex();
+
+            this->reset_registeredUNSAFE();
+
+            for (auto x : deleted_.indices_) {
+                if (elements_.count(x) == 0) continue;
+                elements_.erase(x);
+                names_.erase(id2name_[x]);
+                id2name_.erase(x);
+            }
+
+            deleted_.clear();
+
+            if (clear_all) this->clear_internally();
+            unlockMutex();
+        }
+
+        Element operator[](const std::size_t& index) noexcept {
+
+            auto output = Element();
+
+            lockMutex();
+            if (elements_.count(index) != 0)
+                output = Element(this, index, elements_[index]);
+            else
+                output = Element(this, index, nullptr);
+            unlockMutex();
+
+            if (!output.is_valid()) {
+                OE_Warn("Element with ID: '" + std::to_string(output.id_) + "' does not exist in SharedIndexMap<" +
+                        typeid(T).name() + ">.");
+            }
+
+            return output;
+        }
+
+        Element operator[](const std::string& name) noexcept {
+
+            auto output = Element();
+
+            lockMutex();
+            if (elements_.count(name2id[name]) != 0)
+                output = Element(this, name2id[name], elements_[name2id[name]]);
+            else
+                output = Element(this, name2id[name], nullptr);
+            unlockMutex();
+
+            if (!output.is_valid()) {
+                OE_Warn("Element with name: '" + name + "' does not exist in SharedIndexMap<" + typeid(T).name() + ">.");
+            }
+
+            return output;
+        }
+
+        Element at(const std::size_t& index) {
+
+            auto output = this[0][index];
+
+            if (!output.is_valid()) {
+                throw oe::invalid_element_id("SharedIndexMap<" + std::string(typeid(T).name()) + ">", index);
+            }
+
+            return output;
+        }
+
+        Element at(const std::string& name) {
+
+            auto output = this[0][name];
+
+            if (!output.is_valid()) {
+                throw oe::invalid_element_name("SharedIndexMap<" + std::string(typeid(T).name()) + ">", name);
+            }
+
+            return output;
+        }
+
+        void remove(const std::size_t& index) {
+            lockMutex();
+            this->deleted_.add(index);
+            unlockMutex();
+        }
+
+        //*******************************************/
+        // Regular iterator for interfacing ALL elements
+
+        class Iterator {
+        public:
+            typedef typename std::unordered_map<std::size_t, std::shared_ptr<T>>::iterator map_iter_t;
+            typedef typename std::pair<std::size_t, std::shared_ptr<T>>                    map_iter_element_t;
+
+            using iterator_category = std::input_iterator_tag;
+            using difference_type   = int;
+
+            Iterator(event_container_t<T>& db, map_iter_t beginning) : iter(beginning), db_(db) {
+            }
+
+            Iterator& operator++() {
+                iter++;
+                return *this;
+            }
+            Iterator operator++(int) {
+                Iterator tmp = *this;
+                ++(*this);
+                return tmp;
+            }
+
+            Element operator*() {
+                return db_[(*iter).first];
+            }
+
+            friend bool operator==(const Iterator& a, const Iterator& b) {
+                return a.iter == b.iter;
+            };
+            friend bool operator!=(const Iterator& a, const Iterator& b) {
+                return a.iter != b.iter;
+            };
+
+        private:
+            map_iter_t            iter;
+            event_container_t<T>& db_{nullptr};
+        };
+
+        Iterator begin() {
+            return Iterator(*this, this->elements_.begin());
+        }
+
+        Iterator end() {
+            return Iterator(*this, this->elements_.end());
+        }
+
+        //*******************************************/
+        // Registered class for storing all element indices that registered the previous frame
+
+        class Registered {
+        public:
+            // Registered(){}
+            Registered(event_container_t<T>& inputa) : db_(inputa) {
+            }
+
+            void add(const std::size_t& index) {
+                if ((db_.elements_.count(index) != 0) && (db_.deleted_.count(index) == 0)) indices_.push_back(index);
+            }
+
+            void remove(const std::size_t& index) {
+                if (std::count(indices_.begin(), indices_.end(), index) != 0) {
+                    std::erase(indices_, index);
+                }
+            }
+
+            void clear() {
+                this->indices_.clear();
+            }
+
+            //*******************************************/
+            // Registered iterator for getting the registered events in the right direction
+            class RegisteredIter {
+            public:
+                typedef std::vector<std::size_t>::iterator vector_iter_t;
+
+                using iterator_category = std::input_iterator_tag;
+                using difference_type   = int;
+
+                RegisteredIter(event_container_t<T>& db, vector_iter_t beginning) : iter(beginning), db_(db) {
+                }
+
+                RegisteredIter& operator++() {
+                    iter++;
+                    return *this;
+                }
+                RegisteredIter operator++(int) {
+                    RegisteredIter tmp = *this;
+                    ++(*this);
+                    return tmp;
+                }
+
+                // This needs robust error handling in multiple threads
+                Element operator*() {
+                    return db_[*iter];
+                }
+
+                friend bool operator==(const RegisteredIter& a, const RegisteredIter& b) {
+                    return a.iter == b.iter;
+                };
+                friend bool operator!=(const RegisteredIter& a, const RegisteredIter& b) {
+                    return a.iter != b.iter;
+                };
+
+            protected:
+                vector_iter_t         iter;
+                event_container_t<T>& db_;
+            };
+
+            RegisteredIter begin() {
+                return RegisteredIter(this->db_, this->indices_.begin());
+            }
+
+            RegisteredIter end() {
+                return RegisteredIter(this->db_, this->indices_.end());
+            }
+
+            event_container_t<T>&    db_;
+            std::vector<std::size_t> indices_;
+        };
+
+        Registered registered_;
+
+        Registered registered() {
+            return this->registered_;
+        }
+
+        //*******************************************/
+        // Deleted class for storing all element indices that registered the previous frame
+
+        class Deleted {
+        public:
+            // Deleted(){}
+            Deleted(event_container_t<T>& inputa) : db_(inputa) {
+            }
+
+            void add(const std::size_t& index) {
+                indices_.insert(index);
+                if (db_.elements_.count(index) != 0) {
+                    db_.registered_.remove(index);
+                }
+            }
+
+            void remove(const std::size_t& index) {
+                if (indices_.count(index) != 0) {
+                    indices_.erase(index);
+                }
+            }
+
+            int count(const std::size_t& index) {
+                return this->indices_.count(index);
+            }
+
+            void clear() {
+                this->indices_.clear();
+            }
+
+            //*******************************************/
+            // Deleted iterator for getting only the objects that registered
+            class DeletedIter {
+            public:
+                typedef std::set<std::size_t, std::greater<std::size_t>>::iterator set_iter_t;
+
+                using iterator_category = std::input_iterator_tag;
+                using difference_type   = int;
+
+                DeletedIter(event_container_t<T>& db, set_iter_t beginning) : iter(beginning), db_(db) {
+                }
+
+                DeletedIter& operator++() {
+                    iter++;
+                    return *this;
+                }
+                DeletedIter operator++(int) {
+                    DeletedIter tmp = *this;
+                    ++(*this);
+                    return tmp;
+                }
+
+                Element operator*() {
+                    return db_[*iter];
+                }
+
+                friend bool operator==(const DeletedIter& a, const DeletedIter& b) {
+                    return a.iter == b.iter;
+                };
+                friend bool operator!=(const DeletedIter& a, const DeletedIter& b) {
+                    return a.iter != b.iter;
+                };
+
+            protected:
+                set_iter_t            iter;
+                event_container_t<T>& db_;
+            };
+
+            DeletedIter begin() {
+                return DeletedIter(this->db_, this->indices_.begin());
+            }
+
+            DeletedIter end() {
+                return DeletedIter(this->db_, this->indices_.end());
+            }
+
+            event_container_t<T>&                            db_;
+            std::set<std::size_t, std::greater<std::size_t>> indices_;
+        };
+
+        Deleted deleted_;
+
+        Deleted deleted() {
+            return this->deleted_;
+        }
+    };
+}; // namespace oe
+#endif

--- a/include/OE/Events/event_container.h
+++ b/include/OE/Events/event_container.h
@@ -152,12 +152,12 @@ namespace oe {
 
         void append(const std::string& name, std::shared_ptr<T> element) {
             lockMutex();
-            this->appendUNSAFE_now(name, element);
+            this->appendUNSAFE(name, element);
             unlockMutex();
         }
 
         void appendUNSAFE(const std::string& name, std::shared_ptr<T> element) {
-            if ((this->count(element->id) == 0) && (this->pending_elements_.count(element->id) == 0)) {
+            if ((this->count(element->id) == 0)) {
                 this->elements_[element->id] = element;
                 this->id2name_[element->id]  = name;
                 this->names_.insert(name);
@@ -170,7 +170,7 @@ namespace oe {
 
         void force_append(const std::string& name, std::shared_ptr<T> element) {
             lockMutex();
-            this->force_appendUNSAFE_now(name, element);
+            this->force_appendUNSAFE(name, element);
             unlockMutex();
         }
 
@@ -359,6 +359,10 @@ namespace oe {
                 }
             }
 
+            bool empty() {
+                return this->indices_.empty();
+            }
+
             void clear() {
                 this->indices_.clear();
             }
@@ -418,6 +422,13 @@ namespace oe {
 
         Registered registered() {
             return this->registered_;
+        }
+
+        bool has_registered_events() {
+            lockMutex();
+            bool output = not this->registered_.empty();
+            unlockMutex();
+            return output;
         }
 
         //*******************************************/

--- a/include/OE/Events/event_container.h
+++ b/include/OE/Events/event_container.h
@@ -184,6 +184,7 @@ namespace oe {
             this->elements_[element->id] = element;
             this->id2name_[element->id]  = name;
             this->registered_.add(element->id);
+            this->names_.insert(name);
         }
 
         std::string to_str() {
@@ -251,8 +252,10 @@ namespace oe {
             auto output = Element();
 
             lockMutex();
-            if (elements_.count(name2id[name]) != 0)
-                output = Element(this, name2id[name], elements_[name2id[name]]);
+            if (this->names_.count(name) != 0) {
+                size_t elem_id = name2id[name];
+                output         = Element(this, elem_id, elements_[elem_id]);
+            }
             else
                 output = Element(this, name2id[name], nullptr);
             unlockMutex();

--- a/include/OE/Events/event_handler.h
+++ b/include/OE/Events/event_handler.h
@@ -14,39 +14,39 @@ namespace oe {
 
         // internal event functions
         void                         init();
-        std::shared_ptr<oe::event_t> getIEvent(const std::string&);
+        std::shared_ptr<oe::event_t> get_ievent(const std::string&);
 
-        void createUserEvent(const std::string&);
-        void setIEventFunc(std::size_t, const oe::event_func_type);
-        void setIEventFunc(const std::string&, const oe::event_func_type);
-        void broadcastIEvent(std::size_t);
-        void broadcastIEvent(const std::string&);
+        void create_user_event(const std::string&);
+        void set_ievent_func(std::size_t, const oe::event_func_type);
+        void set_ievent_func(const std::string&, const oe::event_func_type);
+        void broadcast_ievent(std::size_t);
+        void broadcast_ievent(const std::string&);
 
-        void broadcastIEventWait(std::size_t, int); // TODO
-        void mapIEvent(std::size_t, std::size_t);
-        void unmapIEvent(std::size_t, std::size_t);
-        int  callIEvent(std::size_t);
-        void destroyIEvent(std::size_t);
+        void broadcast_ievent_wait(std::size_t, int); // TODO
+        void map_ievent(std::size_t, std::size_t);
+        void unmap_ievent(std::size_t, std::size_t);
+        int  call_ievent(std::size_t);
+        void destroy_ievent(std::size_t);
 
         std::size_t get_event_id(const std::string&);
-        std::size_t getEventActivations(std::size_t);
-        std::size_t getEventCounter(std::size_t);
+        std::size_t get_event_activations(std::size_t);
+        std::size_t get_event_counter(std::size_t);
 
-        void updateInput();
+        void update_input();
         void cleanup();
-        int  handleAllEvents();
+        int  handle_all_events();
 
         // The methods starting with internal* are only supposed to be used
         // in subclasses of OE_WindowSystemBase
         // the key strings must exist
 
         void internal_update_mouse_status(int x, int y, int delta_x, int delta_y);
-        void internalBroadcastKeyDownEvent(const std::string&);
-        void internalBroadcastKeyUpEvent(const std::string&);
+        void internal_register_keydown_event(const std::string&);
+        void internal_register_keyup_event(const std::string&);
 
-        std::atomic<bool> done;
+        std::atomic<bool> done_;
 
-        input_event_handler_t input_handler;
+        input_event_handler_t input_handler_;
 
         int  get_mouse_x();
         int  get_mouse_y();
@@ -55,7 +55,7 @@ namespace oe {
         bool has_mouse_moved();
 
     protected:
-        bool havePendingEvents();
+        bool has_pending_events();
 
         oe::event_container_t<oe::event_t> events_list_;
         // std::map<std::string, std::shared_ptr<oe::event_t>> internal_events;
@@ -65,7 +65,7 @@ namespace oe {
         std::vector<std::size_t>                     happened_events_;
         std::unordered_map<std::size_t, std::size_t> happened_events_counter_;
 
-        uint8_t index = -1;
+        uint8_t index_ = -1;
 
     private:
         int  mouse_x_{0};

--- a/include/OE/Events/event_handler.h
+++ b/include/OE/Events/event_handler.h
@@ -3,62 +3,74 @@
 
 #include <OE/Events/input_event_handler.h>
 
-class OE_EventHandler : public OE_THREAD_SAFETY_OBJECT {
-public:
-    friend class OE_TaskManager;
+namespace oe{
+    class event_handler_t : public OE_THREAD_SAFETY_OBJECT {
+    public:
+        friend class OE_TaskManager;
 
-    OE_EventHandler();
-    ~OE_EventHandler();
+        event_handler_t();
+        ~event_handler_t();
 
-    // internal event functions
-    void                      init();
-    std::shared_ptr<OE_Event> getIEvent(std::string);
-    std::shared_ptr<OE_Event> getIEventUNSAFE(std::string);
+        // internal event functions
+        void                      init();
+        std::shared_ptr<oe::event_t> getIEvent(std::string);
+        std::shared_ptr<oe::event_t> getIEventUNSAFE(std::string);
 
-    void createUserEvent(std::string);
-    void setIEventFunc(std::string, const OE_EVENTFUNC);
-    void broadcastIEvent(std::string);
+        void createUserEvent(std::string);
+        void setIEventFunc(std::string, const oe::event_func_type);
+        void broadcastIEvent(std::string);
 
-    void broadcastIEventWait(std::string, int); // TODO
-    void mapIEvent(std::string, std::string);
-    void unmapIEvent(std::string, std::string);
-    int  callIEvent(std::string);
-    void destroyIEvent(std::string);
+        void broadcastIEventWait(std::string, int); // TODO
+        void mapIEvent(std::string, std::string);
+        void unmapIEvent(std::string, std::string);
+        int  callIEvent(std::string);
+        void destroyIEvent(std::string);
 
-    std::size_t getEventActivations(std::string);
-    std::size_t getEventCounter(std::string);
+        std::size_t getEventActivations(std::string);
+        std::size_t getEventCounter(std::string);
 
-    void updateInput();
-    void cleanup();
-    int  handleAllEvents();
-
-
-    void updatePostInputLoop();
-
-    // The methods starting with internal* are only supposed to be usede
-    // in subclasses of OE_WindowSystemBase
-    // the key strings must exist
-
-    void internalBroadcastKeyDownEvent(const std::string&);
-    void internalBroadcastKeyUpEvent(const std::string&);
-
-    std::atomic<bool> done;
-
-    OE_InputEventHandler input_handler;
-
-protected:
-    bool havePendingEvents();
+        void updateInput();
+        void cleanup();
+        int  handleAllEvents();
 
 
+        void updatePostInputLoop();
 
-    std::map<std::string, std::shared_ptr<OE_Event>> internal_events;
-    std::vector<std::string>                         obsolete_events;
-    std::vector<std::string>                         pending_events;
+        // The methods starting with internal* are only supposed to be usede
+        // in subclasses of OE_WindowSystemBase
+        // the key strings must exist
 
-    std::vector<std::string>                     happened_events;
-    std::unordered_map<std::string, std::size_t> happened_events_counter;
+        void internal_update_mouse_status(int x, int y, int delta_x, int delta_y);
+        void internalBroadcastKeyDownEvent(const std::string&);
+        void internalBroadcastKeyUpEvent(const std::string&);
 
-    uint8_t index = -1;
+        std::atomic<bool> done;
+
+        input_event_handler_t input_handler;
+
+        int get_mouse_x();
+        int get_mouse_y();
+        int get_mouse_delta_y();
+        int get_mouse_delta_x();
+        bool has_mouse_moved();
+
+    protected:
+        bool havePendingEvents();
+
+        std::map<std::string, std::shared_ptr<oe::event_t>> internal_events;
+        std::vector<std::string>                         obsolete_events;
+        std::vector<std::string>                         pending_events;
+
+        std::vector<std::string>                     happened_events;
+        std::unordered_map<std::string, std::size_t> happened_events_counter;
+
+        uint8_t index = -1;
+    private:
+        int mouse_x_{0};
+        int mouse_y_{0};
+        int mouse_delta_y_{0};
+        int mouse_delta_x_{0};
+        bool mouse_moved_{false};
+    };
 };
-
 #endif // OE_EVENT_HANDLER_H

--- a/include/OE/Events/event_handler.h
+++ b/include/OE/Events/event_handler.h
@@ -65,8 +65,6 @@ namespace oe {
         std::vector<std::size_t>                     happened_events_;
         std::unordered_map<std::size_t, std::size_t> happened_events_counter_;
 
-        uint8_t index_ = -1;
-
     private:
         int  mouse_x_{0};
         int  mouse_y_{0};

--- a/include/OE/Events/event_handler.h
+++ b/include/OE/Events/event_handler.h
@@ -58,9 +58,6 @@ namespace oe {
         bool has_pending_events();
 
         oe::event_container_t<oe::event_t> events_list_;
-        // std::map<std::string, std::shared_ptr<oe::event_t>> internal_events;
-        // std::vector<std::string>                            obsolete_events;
-        // std::vector<std::string>                            pending_events;
 
         std::vector<std::size_t>                     happened_events_;
         std::unordered_map<std::size_t, std::size_t> happened_events_counter_;

--- a/include/OE/Events/event_handler.h
+++ b/include/OE/Events/event_handler.h
@@ -1,9 +1,10 @@
 #ifndef OE_EVENT_HANDLER_H
 #define OE_EVENT_HANDLER_H
 
+#include <OE/Events/event_container.h>
 #include <OE/Events/input_event_handler.h>
 
-namespace oe{
+namespace oe {
     class event_handler_t : public OE_THREAD_SAFETY_OBJECT {
     public:
         friend class OE_TaskManager;
@@ -12,7 +13,7 @@ namespace oe{
         ~event_handler_t();
 
         // internal event functions
-        void                      init();
+        void                         init();
         std::shared_ptr<oe::event_t> getIEvent(std::string);
         std::shared_ptr<oe::event_t> getIEventUNSAFE(std::string);
 
@@ -48,29 +49,30 @@ namespace oe{
 
         input_event_handler_t input_handler;
 
-        int get_mouse_x();
-        int get_mouse_y();
-        int get_mouse_delta_y();
-        int get_mouse_delta_x();
+        int  get_mouse_x();
+        int  get_mouse_y();
+        int  get_mouse_delta_y();
+        int  get_mouse_delta_x();
         bool has_mouse_moved();
 
     protected:
         bool havePendingEvents();
 
         std::map<std::string, std::shared_ptr<oe::event_t>> internal_events;
-        std::vector<std::string>                         obsolete_events;
-        std::vector<std::string>                         pending_events;
+        std::vector<std::string>                            obsolete_events;
+        std::vector<std::string>                            pending_events;
 
         std::vector<std::string>                     happened_events;
         std::unordered_map<std::string, std::size_t> happened_events_counter;
 
         uint8_t index = -1;
+
     private:
-        int mouse_x_{0};
-        int mouse_y_{0};
-        int mouse_delta_y_{0};
-        int mouse_delta_x_{0};
+        int  mouse_x_{0};
+        int  mouse_y_{0};
+        int  mouse_delta_y_{0};
+        int  mouse_delta_x_{0};
         bool mouse_moved_{false};
     };
-};
+};     // namespace oe
 #endif // OE_EVENT_HANDLER_H

--- a/include/OE/Events/event_handler.h
+++ b/include/OE/Events/event_handler.h
@@ -14,30 +14,29 @@ namespace oe {
 
         // internal event functions
         void                         init();
-        std::shared_ptr<oe::event_t> getIEvent(std::string);
-        std::shared_ptr<oe::event_t> getIEventUNSAFE(std::string);
+        std::shared_ptr<oe::event_t> getIEvent(const std::string&);
 
-        void createUserEvent(std::string);
-        void setIEventFunc(std::string, const oe::event_func_type);
-        void broadcastIEvent(std::string);
+        void createUserEvent(const std::string&);
+        void setIEventFunc(std::size_t, const oe::event_func_type);
+        void setIEventFunc(const std::string&, const oe::event_func_type);
+        void broadcastIEvent(std::size_t);
+        void broadcastIEvent(const std::string&);
 
-        void broadcastIEventWait(std::string, int); // TODO
-        void mapIEvent(std::string, std::string);
-        void unmapIEvent(std::string, std::string);
-        int  callIEvent(std::string);
-        void destroyIEvent(std::string);
+        void broadcastIEventWait(std::size_t, int); // TODO
+        void mapIEvent(std::size_t, std::size_t);
+        void unmapIEvent(std::size_t, std::size_t);
+        int  callIEvent(std::size_t);
+        void destroyIEvent(std::size_t);
 
-        std::size_t getEventActivations(std::string);
-        std::size_t getEventCounter(std::string);
+        std::size_t get_event_id(const std::string&);
+        std::size_t getEventActivations(std::size_t);
+        std::size_t getEventCounter(std::size_t);
 
         void updateInput();
         void cleanup();
         int  handleAllEvents();
 
-
-        void updatePostInputLoop();
-
-        // The methods starting with internal* are only supposed to be usede
+        // The methods starting with internal* are only supposed to be used
         // in subclasses of OE_WindowSystemBase
         // the key strings must exist
 
@@ -58,12 +57,13 @@ namespace oe {
     protected:
         bool havePendingEvents();
 
-        std::map<std::string, std::shared_ptr<oe::event_t>> internal_events;
-        std::vector<std::string>                            obsolete_events;
-        std::vector<std::string>                            pending_events;
+        oe::event_container_t<oe::event_t> events_list_;
+        // std::map<std::string, std::shared_ptr<oe::event_t>> internal_events;
+        // std::vector<std::string>                            obsolete_events;
+        // std::vector<std::string>                            pending_events;
 
-        std::vector<std::string>                     happened_events;
-        std::unordered_map<std::string, std::size_t> happened_events_counter;
+        std::vector<std::size_t>                     happened_events_;
+        std::unordered_map<std::size_t, std::size_t> happened_events_counter_;
 
         uint8_t index = -1;
 

--- a/include/OE/Events/event_parser.h
+++ b/include/OE/Events/event_parser.h
@@ -7,7 +7,7 @@
 
 /// TODO: INCOMPLETE (READ: NON FUNCTIONAL)
 
-
+/*
 enum OE_EVENT_PAIR_TYPE { OE_NO_COMBO = 0, OE_AND_COMBO = 1, OE_OR_COMBO = 2 };
 
 /// class intended to store a pair (or no pair) of events
@@ -23,7 +23,7 @@ protected:
     OE_EventPair*      event1;
     std::string        name;
 };
-
+*/
 
 
 #endif

--- a/include/OE/Events/input_event_handler.h
+++ b/include/OE/Events/input_event_handler.h
@@ -10,20 +10,16 @@
 namespace oe {
     class input_event_handler_t {
     public:
-        friend class OE_EventHandler;
         friend class OE_TaskManager;
 
         input_event_handler_t();
         ~input_event_handler_t();
 
-        std::map<std::string, std::shared_ptr<oe::event_t>> createEvents();
+        std::map<std::string, std::shared_ptr<oe::event_t>> create_events();
 
         // protected:
-        std::vector<std::string>                 active_events;
-        std::unordered_map<uint8_t, std::string> mouseList;
-        ;
-
-        std::unordered_map<int, std::string> keyList;
+        std::unordered_map<uint8_t, std::string> mouseList_;
+        std::unordered_map<int, std::string>     keyList_;
     };
 };     // namespace oe
 #endif // OE_INPUTEVENTHANDLER_H

--- a/include/OE/Events/input_event_handler.h
+++ b/include/OE/Events/input_event_handler.h
@@ -7,7 +7,7 @@
 /** This class is intended to store any user inputs
  *
  */
-namespace oe{
+namespace oe {
     class input_event_handler_t {
     public:
         friend class OE_EventHandler;
@@ -16,7 +16,7 @@ namespace oe{
         input_event_handler_t();
         ~input_event_handler_t();
 
-        void createEvents(std::map<std::string, std::shared_ptr<oe::event_t>>*);
+        std::map<std::string, std::shared_ptr<oe::event_t>> createEvents();
 
         // protected:
         std::vector<std::string>                 active_events;
@@ -25,5 +25,5 @@ namespace oe{
 
         std::unordered_map<int, std::string> keyList;
     };
-};
+};     // namespace oe
 #endif // OE_INPUTEVENTHANDLER_H

--- a/include/OE/Events/input_event_handler.h
+++ b/include/OE/Events/input_event_handler.h
@@ -19,7 +19,7 @@ namespace oe {
 
         // protected:
         std::unordered_map<uint8_t, std::string> mouseList_;
-        std::unordered_map<int, std::string>     keyList_;
+        std::unordered_map<uint8_t, std::string> keyList_;
     };
 };     // namespace oe
 #endif // OE_INPUTEVENTHANDLER_H

--- a/include/OE/Events/input_event_handler.h
+++ b/include/OE/Events/input_event_handler.h
@@ -7,22 +7,23 @@
 /** This class is intended to store any user inputs
  *
  */
-class OE_InputEventHandler {
-public:
-    friend class OE_EventHandler;
-    friend class OE_TaskManager;
+namespace oe{
+    class input_event_handler_t {
+    public:
+        friend class OE_EventHandler;
+        friend class OE_TaskManager;
 
-    OE_InputEventHandler();
-    ~OE_InputEventHandler();
+        input_event_handler_t();
+        ~input_event_handler_t();
 
-    void createEvents(std::map<std::string, std::shared_ptr<OE_Event>>*);
+        void createEvents(std::map<std::string, std::shared_ptr<oe::event_t>>*);
 
-    // protected:
-    std::vector<std::string>                 active_events;
-    std::unordered_map<uint8_t, std::string> mouseList;
-    ;
+        // protected:
+        std::vector<std::string>                 active_events;
+        std::unordered_map<uint8_t, std::string> mouseList;
+        ;
 
-    std::unordered_map<int, std::string> keyList;
+        std::unordered_map<int, std::string> keyList;
+    };
 };
-
 #endif // OE_INPUTEVENTHANDLER_H

--- a/include/OE/Renderer/DataHandler/data_handler.h
+++ b/include/OE/Renderer/DataHandler/data_handler.h
@@ -3,46 +3,48 @@
 
 #include <OE/Renderer/DataHandler/render_data.h>
 
-class NRE_DataHandler {
-public:
-    bool update(bool, bool);
-    void clear();
+namespace nre {
+    class data_handler_t {
+    public:
+        bool update(bool, bool);
+        void clear();
 
-    void handleMeshData(std::size_t, std::shared_ptr<OE_Mesh32>);
-    void handleMaterialData(std::size_t, std::shared_ptr<OE_Material>);
-    void handleCameraData(std::size_t, std::shared_ptr<OE_Camera>);
-    void handleLightData(std::size_t, std::shared_ptr<OE_Light>);
-    void handleVGroupData(std::size_t, std::size_t, std::shared_ptr<OE_Mesh32>);
+        void handle_mesh_data(std::size_t, std::shared_ptr<OE_Mesh32>);
+        void handle_material_data(std::size_t, std::shared_ptr<OE_Material>);
+        void handle_camera_data(std::size_t, std::shared_ptr<OE_Camera>);
+        void handle_light_data(std::size_t, std::shared_ptr<OE_Light>);
+        void handle_vgroup_data(std::size_t, std::size_t, std::shared_ptr<OE_Mesh32>);
 
-    void handleSceneData(std::size_t, std::shared_ptr<OE_Scene>);
-    void handleViewportData(std::size_t, std::shared_ptr<OE_ViewportConfig>);
+        void handle_scene_data(std::size_t, std::shared_ptr<OE_Scene>);
+        void handle_viewport_data(std::size_t, std::shared_ptr<OE_ViewportConfig>);
 
-    void deleteCamera(std::size_t);
-    void deleteMaterial(std::size_t);
-    void deleteMesh(std::size_t);
+        void delete_camera(std::size_t);
+        void delete_material(std::size_t);
+        void delete_mesh(std::size_t);
 
 
-    bool load_spheres_or_bboxes{false};
+        bool load_spheres_or_bboxes_{false};
 
-    std::size_t                                   loaded_viewport{0};
-    std::map<std::size_t, NRE_CameraRenderData>   cameras;
-    std::map<std::size_t, NRE_MaterialRenderData> materials;
-    std::map<std::size_t, NRE_VGroupRenderData>   vgroups;
-    std::map<std::size_t, NRE_MeshRenderData>     meshes;
+        std::size_t                                        loaded_viewport_{0};
+        std::map<std::size_t, nre::camera_render_data_t>   cameras_;
+        std::map<std::size_t, nre::material_render_data_t> materials_;
+        std::map<std::size_t, nre::vgroup_render_data_t>   vgroups_;
+        std::map<std::size_t, nre::mesh_render_data_t>     meshes_;
 
-    std::map<std::size_t, NRE_DirectionalLightRenderData> dir_lights;
-    std::map<std::size_t, NRE_PointLightRenderData>       pt_lights;
-    bool                                                  has_dir_lights_changed{false};
-    bool                                                  has_pt_lights_changed{false};
+        std::map<std::size_t, nre::directional_light_render_data_t> dir_lights_;
+        std::map<std::size_t, nre::point_light_render_data_t>       pt_lights_;
 
-    std::map<std::size_t, NRE_SceneRenderData>    scenes;
-    std::map<std::size_t, NRE_ViewportRenderData> viewports;
+        bool has_dir_lights_changed_{false};
+        bool has_pt_lights_changed_{false};
 
-    std::set<std::size_t> deleted_meshes;
-    std::set<std::size_t> deleted_materials;
-    std::set<std::size_t> deleted_cameras;
-    std::set<std::size_t> deleted_scenes;
-};
+        std::map<std::size_t, nre::scene_render_data_t>    scenes_;
+        std::map<std::size_t, nre::viewport_render_data_t> viewports_;
 
+        std::set<std::size_t> deleted_meshes_;
+        std::set<std::size_t> deleted_materials_;
+        std::set<std::size_t> deleted_cameras_;
+        std::set<std::size_t> deleted_scenes_;
+    };
+}; // namespace nre
 
 #endif

--- a/include/OE/Renderer/DataHandler/render_data.h
+++ b/include/OE/Renderer/DataHandler/render_data.h
@@ -8,133 +8,133 @@
 
 
 class OE_Mat4x4;
+namespace nre {
+    struct base_object_t {
 
-struct NRE_BaseObject {
+        std::size_t        id{0};
+        bool               changed{false};
+        bool               has_init{false};
+        std::vector<float> data;
+    };
 
-    std::size_t        id{0};
-    bool               changed{false};
-    bool               has_init{false};
-    std::vector<float> data;
-};
+    struct camera_render_data_t : public nre::base_object_t {
+        OE_Mat4x4 perspective_view_mat;
+        OE_Mat4x4 perspective_mat;
+        OE_Mat4x4 view_mat;
+        OE_Mat4x4 model_mat;
 
-struct NRE_CameraRenderData : public NRE_BaseObject {
-    OE_Mat4x4 perspective_view_mat;
-    OE_Mat4x4 perspective_mat;
-    OE_Mat4x4 view_mat;
-    OE_Mat4x4 model_mat;
+        OE_Vec4 get_position();
 
-    OE_Vec4 get_position();
+        float near{0.0f};
+        float far{0.0f};
 
-    float near{0.0f};
-    float far{0.0f};
+        std::size_t  scene_id{0};
+        std::size_t  ubo{0};
+        unsigned int offset{0};
+        unsigned int size{0};
+    };
 
-    std::size_t  scene_id{0};
-    std::size_t  ubo{0};
-    unsigned int offset{0};
-    unsigned int size{0};
-};
+    struct material_render_data_t : public nre::base_object_t {
 
-struct NRE_MaterialRenderData : public NRE_BaseObject {
+        std::size_t scene_id{0};
 
-    std::size_t scene_id{0};
-
-    OE_Vec4 get_mat_diffuse();
-    float   get_mat_specular_hardness();
-
-
-    std::size_t  ubo{0};
-    unsigned int offset{0};
-    unsigned int size{0};
-};
-
-struct NRE_VGroupRenderData {
-
-    std::size_t id{0};
-    OE_Mat4x4   bone_mat;
-
-    std::size_t ibo{0};
-    std::size_t material_id{0};
-    std::size_t mesh_id{0};
-
-    unsigned int offset{0};
-    unsigned int size{0};
-};
-
-struct NRE_MeshRenderData : public NRE_BaseObject {
-
-    std::size_t scene_id{0};
-
-    OE_Mat4x4 model_mat;
-
-    unsigned int uvmaps{0};
-    unsigned int bones{0};
-
-    std::size_t vbo{0};
-    std::size_t vbo_size{0};
-
-    std::size_t  vao{0};
-    std::size_t  ubo{0};
-    unsigned int offset{0};
-    unsigned int size{0};
-
-    bool vao_initialized{false};
-
-    std::vector<nre::gpu::vertex_layout_input> vao_input;
-
-    float max_x{0.0f}, min_x{0.0f}, max_y{0.0f}, min_y{0.0f}, max_z{0.0f}, min_z{0.0f}, max_radius{0.0f}, min_radius{0.0f};
-
-    std::vector<float> get_scaling_min_data();
-    std::vector<float> get_scaling_max_data();
-    std::vector<float> genBoundingBoxVBO();
-
-    // the mesh is used too fetch vertices only
-    std::shared_ptr<OE_Mesh32> mesh{nullptr};
-
-    std::set<size_t> vgroups;
-};
-
-struct NRE_PointLightRenderData : public NRE_BaseObject {
-    OE_Mat4x4 model_mat;
-
-    OE_RGBColor color;
-    float       intensity{0.0f};
-    float       range{0.0f};
-
-    std::size_t  ubo{0};
-    unsigned int offset{0};
-    unsigned int size{0};
-};
-
-struct NRE_DirectionalLightRenderData : public NRE_BaseObject {
-    OE_Mat4x4   model_mat;
-    OE_RGBColor color;
-    float       intensity;
+        OE_Vec4 get_mat_diffuse();
+        float   get_mat_specular_hardness();
 
 
-    std::size_t  ubo{0};
-    unsigned int offset{0};
-    unsigned int size{0};
-};
+        std::size_t  ubo{0};
+        unsigned int offset{0};
+        unsigned int size{0};
+    };
 
-struct NRE_SceneRenderData : public NRE_BaseObject {
+    struct vgroup_render_data_t {
 
-    std::set<std::size_t> cameras;
-    std::set<std::size_t> meshes;
-    std::set<std::size_t> dir_lights;
-    std::set<std::size_t> pt_lights;
-    std::set<std::size_t> materials;
-};
+        std::size_t id{0};
+        OE_Mat4x4   bone_mat;
 
-struct NRE_ViewportRenderData : public NRE_BaseObject {
+        std::size_t ibo{0};
+        std::size_t material_id{0};
+        std::size_t mesh_id{0};
 
-    std::vector<std::size_t> layers;
-    std::vector<std::size_t> cameras;
+        unsigned int offset{0};
+        unsigned int size{0};
+    };
 
-    std::vector<int> camera_modes;
+    struct mesh_render_data_t : public nre::base_object_t {
 
-    std::vector<int> layer_combine_modes;
-    // two floats for each layer, but only useful when there is a split screen in eye coordinates
-    std::vector<float> split_screen_positions;
-};
+        std::size_t scene_id{0};
+
+        OE_Mat4x4 model_mat;
+
+        unsigned int uvmaps{0};
+        unsigned int bones{0};
+
+        std::size_t vbo{0};
+        std::size_t vbo_size{0};
+
+        std::size_t  vao{0};
+        std::size_t  ubo{0};
+        unsigned int offset{0};
+        unsigned int size{0};
+
+        bool vao_initialized{false};
+
+        std::vector<nre::gpu::vertex_layout_input> vao_input;
+
+        float max_x{0.0f}, min_x{0.0f}, max_y{0.0f}, min_y{0.0f}, max_z{0.0f}, min_z{0.0f}, max_radius{0.0f}, min_radius{0.0f};
+
+        std::vector<float> get_scaling_min_data();
+        std::vector<float> get_scaling_max_data();
+
+        // the mesh is used too fetch vertices only
+        std::shared_ptr<OE_Mesh32> mesh{nullptr};
+
+        std::set<size_t> vgroups;
+    };
+
+    struct point_light_render_data_t : public nre::base_object_t {
+        OE_Mat4x4 model_mat;
+
+        OE_RGBColor color;
+        float       intensity{0.0f};
+        float       range{0.0f};
+
+        std::size_t  ubo{0};
+        unsigned int offset{0};
+        unsigned int size{0};
+    };
+
+    struct directional_light_render_data_t : public nre::base_object_t {
+        OE_Mat4x4   model_mat;
+        OE_RGBColor color;
+        float       intensity;
+
+
+        std::size_t  ubo{0};
+        unsigned int offset{0};
+        unsigned int size{0};
+    };
+
+    struct scene_render_data_t : public nre::base_object_t {
+
+        std::set<std::size_t> cameras;
+        std::set<std::size_t> meshes;
+        std::set<std::size_t> dir_lights;
+        std::set<std::size_t> pt_lights;
+        std::set<std::size_t> materials;
+    };
+
+    struct viewport_render_data_t : public nre::base_object_t {
+
+        std::vector<std::size_t> layers;
+        std::vector<std::size_t> cameras;
+
+        std::vector<int> camera_modes;
+
+        std::vector<int> layer_combine_modes;
+        // two floats for each layer, but only useful when there is a split screen in eye coordinates
+        std::vector<float> split_screen_positions;
+    };
+}; // namespace nre
 
 #endif // FE_MESHRENDERDATA_H

--- a/include/OE/Renderer/GL3/api_gl3.h
+++ b/include/OE/Renderer/GL3/api_gl3.h
@@ -186,6 +186,7 @@ public:
     void draw_instanced(std::size_t, std::size_t, std::size_t, std::size_t);
 
     void setRenderMode(nre::gpu::RENDERMODE);
+    void use_wireframe(bool);
 
 protected:
     std::size_t cur_rbo{0};
@@ -248,6 +249,9 @@ private:
     GLuint active_prog_{0};
     // every VAO in OpenGL stores its Index Buffer
     std::unordered_map<GLuint, GLuint> vao_ibos_;
+
+    uint32_t x_{0};
+    uint32_t y_{0};
 };
 
 

--- a/include/OE/Renderer/GL3/api_gl3.h
+++ b/include/OE/Renderer/GL3/api_gl3.h
@@ -79,9 +79,19 @@ struct NRE_GL3_Program {
     bool   prog_created{false};
     GLuint handle{0};
 
-    // this is needed for it to be in an std::set
-    bool operator<(const NRE_GL3_Program&) const;
+    // this is needed for it to be in an std::unordered_set
+    bool   operator==(const NRE_GL3_Program&) const;
+    size_t gen_hash() const;
 };
+
+namespace std {
+    template <>
+    struct hash<NRE_GL3_Program> {
+        auto operator()(const NRE_GL3_Program& xyz) const -> size_t {
+            return hash<size_t>{}(xyz.gen_hash());
+        }
+    };
+} // namespace std
 
 struct NRE_GL3_ProgramData {
     GLuint                                   handle{0};
@@ -198,9 +208,9 @@ protected:
 
     std::size_t getVAOSize(std::size_t);
 
-    std::map<nre::gpu::vertex_shader, GLuint>      vs_db;
-    std::map<nre::gpu::pixel_shader, GLuint>       fs_db;
-    std::map<NRE_GL3_Program, NRE_GL3_ProgramData> prog_db;
+    std::unordered_map<nre::gpu::vertex_shader, GLuint>      vs_db;
+    std::unordered_map<nre::gpu::pixel_shader, GLuint>       fs_db;
+    std::unordered_map<NRE_GL3_Program, NRE_GL3_ProgramData> prog_db;
 
 private:
     void check_rbo_id_(std::size_t, const std::string&);

--- a/include/OE/Renderer/GL3/api_gl3.h
+++ b/include/OE/Renderer/GL3/api_gl3.h
@@ -67,13 +67,13 @@ struct NRE_GL3_ProgramUniformState {
 
 struct NRE_GL3_Program {
 
-    nre::gpu::vertex_shader vs;
-    GLuint                  vs_handle{0};
-    bool                    vs_setup{false};
+    nre::gpu::vertex_shader_t vs;
+    GLuint                    vs_handle{0};
+    bool                      vs_setup{false};
 
-    nre::gpu::pixel_shader fs;
-    GLuint                 fs_handle{0};
-    bool                   fs_setup{false};
+    nre::gpu::pixel_shader_t fs;
+    GLuint                   fs_handle{0};
+    bool                     fs_setup{false};
 
     bool   setup{false};
     bool   prog_created{false};
@@ -165,8 +165,8 @@ public:
     void clearFrameBuffer(std::size_t, nre::gpu::FRAMEBUFFER_COPY, float);
     void deleteFrameBuffer(std::size_t);
 
-    void setProgramVS(std::size_t, nre::gpu::vertex_shader);
-    void setProgramFS(std::size_t, nre::gpu::pixel_shader);
+    void setProgramVS(std::size_t, nre::gpu::vertex_shader_t);
+    void setProgramFS(std::size_t, nre::gpu::pixel_shader_t);
 
     void setProgramVS(std::size_t, std::string);
     // void setProgramGS(std::size_t, FE_GPU_Shader);
@@ -209,8 +209,8 @@ protected:
 
     std::size_t getVAOSize(std::size_t);
 
-    std::unordered_map<nre::gpu::vertex_shader, GLuint>      vs_db;
-    std::unordered_map<nre::gpu::pixel_shader, GLuint>       fs_db;
+    std::unordered_map<nre::gpu::vertex_shader_t, GLuint>    vs_db;
+    std::unordered_map<nre::gpu::pixel_shader_t, GLuint>     fs_db;
     std::unordered_map<NRE_GL3_Program, NRE_GL3_ProgramData> prog_db;
 
 private:
@@ -250,8 +250,11 @@ private:
     // every VAO in OpenGL stores its Index Buffer
     std::unordered_map<GLuint, GLuint> vao_ibos_;
 
-    uint32_t x_{0};
-    uint32_t y_{0};
+    uint32_t                 x_{0};
+    uint32_t                 y_{0};
+    nre::gpu::SHADER_BACKEND backend_;
+    int                      major_{3};
+    int                      minor_{3};
 };
 
 

--- a/include/OE/Renderer/GL3/api_gl3.h
+++ b/include/OE/Renderer/GL3/api_gl3.h
@@ -1,262 +1,268 @@
-#ifndef NRE_GL3_API_H_INCLUDED
-#define NRE_GL3_API_H_INCLUDED
+#ifndef api_t_H_INCLUDED
+#define api_t_H_INCLUDED
 
 
 #include <OE/Renderer/GL3/shaders_gl3.h>
 #include <OE/Renderer/api_gpu.h>
 #include <OE/types/libs_oe.h>
 
-struct NRE_GL3_RenderBuffer {
-    GLuint                 handle{0};
-    nre::gpu::TEXTURE_TYPE type;
-    int                    x{0};
-    int                    y{0};
+namespace nre { namespace gl3 {
+    struct renderbuffer_t {
+        GLuint                 handle{0};
+        nre::gpu::TEXTURE_TYPE type;
+        int                    x{0};
+        int                    y{0};
 
-    bool hasNotChanged(nre::gpu::TEXTURE_TYPE, int, int);
-};
+        bool has_not_changed(nre::gpu::TEXTURE_TYPE, int, int);
+    };
 
-struct NRE_GL3_VertexBuffer {
-    GLuint                 handle;
-    std::size_t            size;
-    nre::gpu::BUFFER_USAGE usage;
-};
+    struct vertex_buffer_t {
+        GLuint                 handle;
+        std::size_t            size;
+        nre::gpu::BUFFER_USAGE usage;
+    };
 
-struct NRE_GL3_IndexBuffer {
-    GLuint                 handle;
-    std::size_t            size;
-    nre::gpu::BUFFER_USAGE usage;
-};
+    struct index_buffer_t {
+        GLuint                 handle;
+        std::size_t            size;
+        nre::gpu::BUFFER_USAGE usage;
+    };
 
-struct NRE_GL3_FrameBuffer {
-    GLuint handle;
-    // int components{0};
-    // bool depth{false};
-    // bool stencil{false};
-    std::size_t texture{0};
-};
+    struct framebuffer_t {
+        GLuint handle;
+        // int components{0};
+        // bool depth{false};
+        // bool stencil{false};
+        std::size_t texture{0};
+    };
 
-struct NRE_GL3_Texture {
-    GLuint                   handle;
-    nre::gpu::TEXTURE_TYPE   type;
-    nre::gpu::TEXTURE_FILTER filter;
-    int                      x{0};
-    int                      y{0};
-    int                      mipmaps{0};
+    struct texture_t {
+        GLuint                   handle;
+        nre::gpu::TEXTURE_TYPE   type;
+        nre::gpu::TEXTURE_FILTER filter;
+        int                      x{0};
+        int                      y{0};
+        int                      mipmaps{0};
 
-    bool hasNotChanged(nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, int, int, int);
-};
+        bool has_not_changed(nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, int, int, int);
+    };
 
-struct NRE_GL3_VertexArray {
-    GLuint                                     handle;
-    std::vector<nre::gpu::vertex_layout_input> layout;
-};
+    struct vertex_layout_t {
+        GLuint                                     handle;
+        std::vector<nre::gpu::vertex_layout_input> layout;
+    };
 
-struct NRE_GL3_UniformBuffer {
-    GLuint                 handle;
-    std::size_t            size;
-    nre::gpu::BUFFER_USAGE usage;
-    GLint                  slot;
-};
+    struct uniform_buffer_t {
+        GLuint                 handle;
+        std::size_t            size;
+        nre::gpu::BUFFER_USAGE usage;
+        GLint                  slot;
+    };
 
-struct NRE_GL3_ProgramUniformState {
-    std::string name;
-    GLint       slot{0};
-    GLenum      type{GL_FLOAT}; // unused in Uniform blocks
-    size_t      size{0};        // unused in Uniform Blocks
-};
+    struct program_uniform_state_t {
+        GLint  slot{0};
+        GLenum type{GL_FLOAT}; // unused in Uniform blocks
+        size_t size{0};        // unused in Uniform Blocks
+    };
 
-struct NRE_GL3_Program {
+    struct program_data_t {
+        GLuint handle{0};
 
-    nre::gpu::vertex_shader_t vs;
-    GLuint                    vs_handle{0};
-    bool                      vs_setup{false};
+        std::unordered_map<std::string, program_uniform_state_t> uniform_blocks;
+        std::unordered_map<std::string, GLuint>                  uniform_block_indices;
+        bool                                                     has_uniform_block(const std::string&);
 
-    nre::gpu::pixel_shader_t fs;
-    GLuint                   fs_handle{0};
-    bool                     fs_setup{false};
+        std::unordered_map<std::string, program_uniform_state_t> uniforms;
+        bool                                                     has_uniform(const std::string&);
+    };
 
-    bool   setup{false};
-    bool   prog_created{false};
-    GLuint handle{0};
+    struct program_t {
 
-    // this is needed for it to be in an std::unordered_set
-    bool   operator==(const NRE_GL3_Program&) const;
-    size_t gen_hash() const;
-};
+        nre::gpu::vertex_shader_t vs;
+        GLuint                    vs_handle{0};
+        bool                      vs_setup{false};
+
+        nre::gpu::pixel_shader_t fs;
+        GLuint                   fs_handle{0};
+        bool                     fs_setup{false};
+
+        bool   setup{false};
+        bool   prog_created{false};
+        GLuint handle{0};
+
+        // this is needed for it to be in an std::unordered_set
+        bool   operator==(const program_t&) const;
+        size_t gen_hash() const;
+    };
+}; }; // namespace nre::gl3
 
 namespace std {
     template <>
-    struct hash<NRE_GL3_Program> {
-        auto operator()(const NRE_GL3_Program& xyz) const -> size_t {
+    struct hash<nre::gl3::program_t> {
+        auto operator()(const nre::gl3::program_t& xyz) const -> size_t {
             return hash<size_t>{}(xyz.gen_hash());
         }
     };
 } // namespace std
 
-struct NRE_GL3_ProgramData {
-    GLuint                                   handle{0};
-    std::vector<NRE_GL3_ProgramUniformState> uniform_blocks;
-    std::size_t                              hasUniformBlock(std::string);
+namespace nre { namespace gl3 {
 
-    std::vector<NRE_GL3_ProgramUniformState> uniforms;
-    std::size_t                              hasUniform(std::string);
-};
 
-GLenum NRE2GL_BufferUse(nre::gpu::BUFFER_USAGE);
+    GLenum buffer_use(nre::gpu::BUFFER_USAGE);
 
-class NRE_GL3_API {
-public:
-    NRE_GL3_API(nre::gpu::info_struct&);
-    ~NRE_GL3_API();
+    class api_t {
+    public:
+        api_t(nre::gpu::info_struct&);
+        ~api_t();
 
-    void update(uint32_t, uint32_t);
+        void update(uint32_t, uint32_t);
 
-    void destroy();
+        void destroy();
 
-    std::string getRenderingAPI();
+        std::string get_rendering_api();
 
-    std::size_t newVertexBuffer();
-    std::size_t newVertexLayout();
-    std::size_t newIndexBuffer();
-    std::size_t newProgram();
-    std::size_t newUniformBuffer();
-    std::size_t newFrameBuffer();
-    std::size_t newTexture();
-    std::size_t newRenderBuffer();
+        std::size_t new_vertex_buffer();
+        std::size_t new_vertex_layout();
+        std::size_t new_index_buffer();
+        std::size_t new_program();
+        std::size_t new_uniform_buffer();
+        std::size_t new_framebuffer();
+        std::size_t new_texture();
+        std::size_t new_renderbuffer();
 
-    void setRenderBufferType(std::size_t, nre::gpu::TEXTURE_TYPE, int, int);
-    void setFrameBufferRenderBuffer(std::size_t, std::size_t, int);
+        void set_renderbuffer_textype(std::size_t, nre::gpu::TEXTURE_TYPE, int, int);
+        void set_framebuffer_renderbuffer(std::size_t, std::size_t, int);
 
-    void setVertexBufferMemory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
-    void setVertexBufferData(std::size_t, const std::vector<float>&, std::size_t);
-    void setVertexBufferMemoryData(std::size_t, const std::vector<float>&, nre::gpu::BUFFER_USAGE);
-    void deleteVertexBuffer(std::size_t);
+        void set_vertex_buffer_memory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
+        void set_vertex_buffer_data(std::size_t, const std::vector<float>&, std::size_t);
+        void set_vertex_buffer_memory_data(std::size_t, const std::vector<float>&, nre::gpu::BUFFER_USAGE);
+        void delete_vertex_buffer(std::size_t);
 
-    void setIndexBufferMemory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
-    void setIndexBufferData(std::size_t, const std::vector<uint32_t>&, std::size_t);
-    void setIndexBufferMemoryData(std::size_t, const std::vector<uint32_t>&, nre::gpu::BUFFER_USAGE);
-    void deleteIndexBuffer(std::size_t);
+        void set_index_buffer_memory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
+        void set_index_buffer_data(std::size_t, const std::vector<uint32_t>&, std::size_t);
+        void set_index_buffer_memory_data(std::size_t, const std::vector<uint32_t>&, nre::gpu::BUFFER_USAGE);
+        void delete_index_buffer(std::size_t);
 
-    void setUniformBufferMemory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
-    void setUniformBufferData(std::size_t, const std::vector<float>&, std::size_t);
-    void setUniformBufferData(std::size_t, const std::vector<uint32_t>&, std::size_t);
+        void set_uniform_buffer_memory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
+        void set_uniform_buffer_data(std::size_t, const std::vector<float>&, std::size_t);
+        void set_uniform_buffer_data(std::size_t, const std::vector<uint32_t>&, std::size_t);
 
-    void setProgramUniformBlockSlot(std::size_t, std::string, int);
-    int  getProgramUniformBlockSlot(std::size_t, std::string);
+        void set_program_uniform_block_slot(std::size_t, const std::string&, int);
+        int  get_program_uniform_block_slot(std::size_t, const std::string&);
 
-    void setProgramTextureSlot(std::size_t, std::string, int);
-    void setProgramUniformData(std::size_t, std::string, uint32_t);
-    void setProgramUniformData(std::size_t, std::string, std::vector<uint32_t>);
-    int  getProgramUniformSlot(std::size_t, std::string);
+        void set_program_texture_slot(std::size_t, const std::string&, int);
+        void set_program_uniform_data(std::size_t, const std::string&, uint32_t);
+        void set_program_uniform_data(std::size_t, const std::string&, std::vector<uint32_t>);
+        int  get_program_uniform_slot(std::size_t, const std::string&);
 
-    void setUniformBlockState(std::size_t, std::size_t, int, std::size_t, std::size_t);
-    void deleteUniformBuffer(std::size_t);
+        void set_uniform_block_state(std::size_t, std::size_t, int, std::size_t, std::size_t);
+        void delete_uniform_buffer(std::size_t);
 
-    void setVertexLayoutFormat(std::size_t, std::vector<nre::gpu::vertex_layout_input>);
-    void deleteVertexLayout(std::size_t);
+        void set_vertex_layout_format(std::size_t, std::vector<nre::gpu::vertex_layout_input>);
+        void delete_vertex_layout(std::size_t);
 
-    void setTextureFormat(std::size_t, nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, uint32_t, uint32_t, int);
-    void setFrameBufferTexture(std::size_t, std::size_t, int);
-    void setTextureSlot(std::size_t, int);
-    void deleteTexture(std::size_t);
+        void set_texture_format(std::size_t, nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, uint32_t, uint32_t, int);
+        void set_framebuffer_texture(std::size_t, std::size_t, int);
+        void set_texture_slot(std::size_t, int);
+        void delete_texture(std::size_t);
 
-    void copyFrameBuffer(std::size_t, std::size_t, nre::gpu::FRAMEBUFFER_COPY);
-    void useFrameBuffer(std::size_t);
-    void clearFrameBuffer(std::size_t, nre::gpu::FRAMEBUFFER_COPY, float);
-    void deleteFrameBuffer(std::size_t);
+        void copy_framebuffer(std::size_t, std::size_t, nre::gpu::FRAMEBUFFER_COPY);
+        void use_framebuffer(std::size_t);
+        void clear_framebuffer(std::size_t, nre::gpu::FRAMEBUFFER_COPY, float);
+        void delete_framebuffer(std::size_t);
 
-    void setProgramVS(std::size_t, nre::gpu::vertex_shader_t);
-    void setProgramFS(std::size_t, nre::gpu::pixel_shader_t);
+        void set_program_vs(std::size_t, nre::gpu::vertex_shader_t);
+        void set_program_fs(std::size_t, nre::gpu::pixel_shader_t);
 
-    void setProgramVS(std::size_t, std::string);
-    // void setProgramGS(std::size_t, FE_GPU_Shader);
-    void setProgramFS(std::size_t, std::string);
-    // void setProgramTCS(std::size_t, FE_GPU_Shader);
-    // void setProgramTES(std::size_t, FE_GPU_Shader);
-    void setupProgram(std::size_t);
-    void deleteProgram(std::size_t);
+        void set_program_vs(std::size_t, std::string);
+        // void set_programGS(std::size_t, FE_GPU_Shader);
+        void set_program_fs(std::size_t, std::string);
+        // void set_programTCS(std::size_t, FE_GPU_Shader);
+        // void set_programTES(std::size_t, FE_GPU_Shader);
+        void setup_program(std::size_t);
+        void delete_program(std::size_t);
 
-    void draw(std::size_t, std::size_t, int, int);
-    void draw(std::size_t, std::size_t);
+        void draw(std::size_t, std::size_t, int, int);
+        void draw(std::size_t, std::size_t);
 
-    void draw(std::size_t, std::size_t, std::size_t, int, int);
-    void draw(std::size_t, std::size_t, std::size_t);
+        void draw(std::size_t, std::size_t, std::size_t, int, int);
+        void draw(std::size_t, std::size_t, std::size_t);
 
-    void draw_instanced(std::size_t, std::size_t, std::size_t);
-    void draw_instanced(std::size_t, std::size_t, std::size_t, std::size_t);
+        void draw_instanced(std::size_t, std::size_t, std::size_t);
+        void draw_instanced(std::size_t, std::size_t, std::size_t, std::size_t);
 
-    void setRenderMode(nre::gpu::RENDERMODE);
-    void use_wireframe(bool);
+        void set_render_mode(nre::gpu::RENDERMODE);
+        void use_wireframe(bool);
 
-protected:
-    std::size_t cur_rbo{0};
-    std::size_t cur_vbo{0};
-    std::size_t cur_ibo{0};
-    std::size_t cur_vao{0};
-    std::size_t cur_ubo{0};
-    std::size_t cur_fbo{0};
-    std::size_t cur_texture{0};
-    std::size_t cur_prog{0};
+    protected:
+        std::size_t cur_rbo_{0};
+        std::size_t cur_vbo_{0};
+        std::size_t cur_ibo_{0};
+        std::size_t cur_vao_{0};
+        std::size_t cur_ubo_{0};
+        std::size_t cur_fbo_{0};
+        std::size_t cur_texture_{0};
+        std::size_t cur_prog_{0};
 
-    std::unordered_map<std::size_t, NRE_GL3_RenderBuffer>  rbos;
-    std::unordered_map<std::size_t, NRE_GL3_VertexBuffer>  vbos;
-    std::unordered_map<std::size_t, NRE_GL3_IndexBuffer>   ibos;
-    std::unordered_map<std::size_t, NRE_GL3_VertexArray>   vaos;
-    std::unordered_map<std::size_t, NRE_GL3_UniformBuffer> ubos;
-    std::unordered_map<std::size_t, NRE_GL3_FrameBuffer>   fbos;
-    std::unordered_map<std::size_t, NRE_GL3_Texture>       textures;
-    std::unordered_map<std::size_t, NRE_GL3_Program>       progs;
+        std::unordered_map<std::size_t, renderbuffer_t>   rbos_;
+        std::unordered_map<std::size_t, vertex_buffer_t>  vbos_;
+        std::unordered_map<std::size_t, index_buffer_t>   ibos_;
+        std::unordered_map<std::size_t, vertex_layout_t>  vaos_;
+        std::unordered_map<std::size_t, uniform_buffer_t> ubos_;
+        std::unordered_map<std::size_t, framebuffer_t>    fbos_;
+        std::unordered_map<std::size_t, texture_t>        textures_;
+        std::unordered_map<std::size_t, program_t>        progs_;
 
-    std::size_t getVAOSize(std::size_t);
+        std::size_t get_vao_size(std::size_t);
 
-    std::unordered_map<nre::gpu::vertex_shader_t, GLuint>    vs_db;
-    std::unordered_map<nre::gpu::pixel_shader_t, GLuint>     fs_db;
-    std::unordered_map<NRE_GL3_Program, NRE_GL3_ProgramData> prog_db;
+        std::unordered_map<nre::gpu::vertex_shader_t, GLuint> vs_db_;
+        std::unordered_map<nre::gpu::pixel_shader_t, GLuint>  fs_db_;
+        std::unordered_map<program_t, program_data_t>         prog_db_;
 
-private:
-    void check_rbo_id_(std::size_t, const std::string&);
-    void check_vbo_id_(std::size_t, const std::string&);
-    void check_ubo_id_(std::size_t, const std::string&);
-    void check_ibo_id_(std::size_t, const std::string&);
+    private:
+        void check_rbo_id_(std::size_t, const std::string&);
+        void check_vbo_id_(std::size_t, const std::string&);
+        void check_ubo_id_(std::size_t, const std::string&);
+        void check_ibo_id_(std::size_t, const std::string&);
 
-    void check_vbo_offset_length_(std::size_t, std::size_t, const std::string&);
-    void check_ubo_offset_length_(std::size_t, std::size_t, const std::string&);
-    void check_ibo_offset_length_(std::size_t, std::size_t, const std::string&);
+        void check_vbo_offset_length_(std::size_t, std::size_t, const std::string&);
+        void check_ubo_offset_length_(std::size_t, std::size_t, const std::string&);
+        void check_ibo_offset_length_(std::size_t, std::size_t, const std::string&);
 
-    void check_vao_id_(std::size_t, const std::string&);
-    void check_prog_id_(std::size_t, const std::string&);
-    void check_prog_complete_(std::size_t, const std::string&);
+        void check_vao_id_(std::size_t, const std::string&);
+        void check_prog_id_(std::size_t, const std::string&);
+        void check_prog_complete_(std::size_t, const std::string&);
 
-    void check_prog_uniform_block_(std::size_t, const std::string&, const std::string&);
-    void check_prog_uniform_(std::size_t, const std::string&, const std::string&);
-    void check_prog_uniform_property_(std::size_t, const std::string&, std::size_t, const std::string&, bool);
-    void check_vao_vbo_(std::size_t, std::size_t, const std::string&);
+        void check_prog_uniform_block_(std::size_t, const std::string&, const std::string&);
+        void check_prog_uniform_(std::size_t, const std::string&, const std::string&);
+        void check_prog_uniform_property_(std::size_t, const std::string&, std::size_t, const std::string&, bool);
+        void check_vao_vbo_(std::size_t, std::size_t, const std::string&);
 
-    void check_fbo_id_(std::size_t, const std::string&);
-    void check_texture_id_(std::size_t, const std::string&);
-    void check_draw_range_(std::size_t, std::size_t, std::size_t, std::size_t, const std::string&);
+        void check_fbo_id_(std::size_t, const std::string&);
+        void check_texture_id_(std::size_t, const std::string&);
+        void check_draw_range_(std::size_t, std::size_t, std::size_t, std::size_t, const std::string&);
 
-    void get_program_all_uniforms_(std::size_t);
+        void get_program_all_uniforms_(std::size_t);
 
-    int teximage_internalformat_(nre::gpu::TEXTURE_TYPE);
-    int teximage_format_(nre::gpu::TEXTURE_TYPE);
-    int teximage_type_(nre::gpu::TEXTURE_TYPE);
+        int teximage_internalformat_(nre::gpu::TEXTURE_TYPE);
+        int teximage_format_(nre::gpu::TEXTURE_TYPE);
+        int teximage_type_(nre::gpu::TEXTURE_TYPE);
 
-    // this is useful for preventing OpenGL glBind* command repetitions
-    GLuint active_vbo_{0};
-    GLuint active_vao_{0};
-    GLuint active_ubo_{0};
-    GLuint active_prog_{0};
-    // every VAO in OpenGL stores its Index Buffer
-    std::unordered_map<GLuint, GLuint> vao_ibos_;
+        // this is useful for preventing OpenGL glBind* command repetitions
+        GLuint active_vbo_{0};
+        GLuint active_vao_{0};
+        GLuint active_ubo_{0};
+        GLuint active_prog_{0};
+        // every VAO in OpenGL stores its Index Buffer
+        std::unordered_map<GLuint, GLuint> vao_ibos_;
 
-    uint32_t                 x_{0};
-    uint32_t                 y_{0};
-    nre::gpu::SHADER_BACKEND backend_;
-    int                      major_{3};
-    int                      minor_{3};
-};
-
+        uint32_t                 x_{0};
+        uint32_t                 y_{0};
+        nre::gpu::SHADER_BACKEND backend_;
+        int                      major_{3};
+        int                      minor_{3};
+    };
+}; }; // namespace nre::gl3
 
 
 #endif

--- a/include/OE/Renderer/GL3/api_gl3.h
+++ b/include/OE/Renderer/GL3/api_gl3.h
@@ -115,7 +115,7 @@ namespace nre { namespace gl3 {
         api_t(nre::gpu::info_struct&);
         ~api_t();
 
-        void update(uint32_t, uint32_t);
+        void update(uint32_t, uint32_t, bool);
 
         void destroy();
 
@@ -261,6 +261,7 @@ namespace nre { namespace gl3 {
         nre::gpu::SHADER_BACKEND backend_;
         int                      major_{3};
         int                      minor_{3};
+        bool                     sanity_checks_{true};
     };
 }; }; // namespace nre::gl3
 

--- a/include/OE/Renderer/GL3/shaders_gl3.h
+++ b/include/OE/Renderer/GL3/shaders_gl3.h
@@ -3,8 +3,9 @@
 
 #include <OE/Renderer/shaders_gpu.h>
 
-
-std::string NRE_GenGL3VertexShader(nre::gpu::vertex_shader);
-std::string NRE_GenGL3PixelShader(nre::gpu::pixel_shader);
+namespace nre { namespace gl3 {
+    std::string gen_vertex_shader(nre::gpu::vertex_shader_t);
+    std::string gen_pixel_shader(nre::gpu::pixel_shader_t);
+}; }; // namespace nre::gl3
 
 #endif

--- a/include/OE/Renderer/GLES2/api_gles2.h
+++ b/include/OE/Renderer/GLES2/api_gles2.h
@@ -61,13 +61,13 @@ struct NRE_GLES2_ProgramUniformState {
 
 struct NRE_GLES2_Program {
 
-    nre::gpu::vertex_shader vs;
-    GLuint                  vs_handle{0};
-    bool                    vs_setup{false};
+    nre::gpu::vertex_shader_t vs;
+    GLuint                    vs_handle{0};
+    bool                      vs_setup{false};
 
-    nre::gpu::pixel_shader fs;
-    GLuint                 fs_handle{0};
-    bool                   fs_setup{false};
+    nre::gpu::pixel_shader_t fs;
+    GLuint                   fs_handle{0};
+    bool                     fs_setup{false};
 
     bool   setup{false};
     bool   prog_created{false};
@@ -147,8 +147,8 @@ public:
     void clearFrameBuffer(std::size_t, nre::gpu::FRAMEBUFFER_COPY, float);
     void deleteFrameBuffer(std::size_t);
 
-    void setProgramVS(std::size_t, nre::gpu::vertex_shader);
-    void setProgramFS(std::size_t, nre::gpu::pixel_shader);
+    void setProgramVS(std::size_t, nre::gpu::vertex_shader_t);
+    void setProgramFS(std::size_t, nre::gpu::pixel_shader_t);
 
     void setProgramVS(std::size_t, std::string);
     // void setProgramGS(std::size_t, FE_GPU_Shader);
@@ -184,8 +184,8 @@ protected:
 
     std::size_t getVAOSize(std::size_t);
 
-    std::unordered_map<nre::gpu::vertex_shader, GLuint>          vs_db;
-    std::unordered_map<nre::gpu::pixel_shader, GLuint>           fs_db;
+    std::unordered_map<nre::gpu::vertex_shader_t, GLuint>        vs_db;
+    std::unordered_map<nre::gpu::pixel_shader_t, GLuint>         fs_db;
     std::unordered_map<NRE_GLES2_Program, NRE_GLES2_ProgramData> prog_db;
 
 private:
@@ -241,6 +241,8 @@ private:
 
     uint32_t x_{0};
     uint32_t y_{0};
+    int      major_{2};
+    int      minor_{0};
 };
 
 #endif

--- a/include/OE/Renderer/GLES2/api_gles2.h
+++ b/include/OE/Renderer/GLES2/api_gles2.h
@@ -6,243 +6,247 @@
 #include <OE/Renderer/api_gpu.h>
 #include <OE/types/libs_oe.h>
 
-struct NRE_GLES2_RenderBuffer {
-    GLuint                 handle{0};
-    nre::gpu::TEXTURE_TYPE type;
-    int                    x{0};
-    int                    y{0};
+namespace nre { namespace gles2 {
+    struct renderbuffer_t {
+        GLuint                 handle{0};
+        nre::gpu::TEXTURE_TYPE type;
+        int                    x{0};
+        int                    y{0};
 
-    bool hasNotChanged(nre::gpu::TEXTURE_TYPE, int, int);
-};
+        bool has_not_changed(nre::gpu::TEXTURE_TYPE, int, int);
+    };
 
-struct NRE_GLES2_VertexBuffer {
-    GLuint                 handle;
-    std::size_t            size;
-    nre::gpu::BUFFER_USAGE usage;
-};
+    struct vertex_buffer_t {
+        GLuint                 handle;
+        std::size_t            size;
+        nre::gpu::BUFFER_USAGE usage;
+    };
 
-struct NRE_GLES2_IndexBuffer {
-    GLuint                 handle;
-    std::size_t            size;
-    GLenum                 type_{GL_UNSIGNED_INT};
-    nre::gpu::BUFFER_USAGE usage;
-};
+    struct index_buffer_t {
+        GLuint                 handle;
+        std::size_t            size;
+        GLenum                 type_{GL_UNSIGNED_INT};
+        nre::gpu::BUFFER_USAGE usage;
+    };
 
-struct NRE_GLES2_FrameBuffer {
-    GLuint handle;
-    // int components{0};
-    // bool depth{false};
-    // bool stencil{false};
-    std::size_t texture{0};
-};
+    struct framebuffer_t {
+        GLuint handle;
+        // int components{0};
+        // bool depth{false};
+        // bool stencil{false};
+        std::size_t texture{0};
+    };
 
-struct NRE_GLES2_Texture {
-    GLuint                   handle;
-    nre::gpu::TEXTURE_TYPE   type;
-    nre::gpu::TEXTURE_FILTER filter;
-    int                      x{0};
-    int                      y{0};
-    int                      mipmaps{0};
+    struct texture_t {
+        GLuint                   handle;
+        nre::gpu::TEXTURE_TYPE   type;
+        nre::gpu::TEXTURE_FILTER filter;
+        int                      x{0};
+        int                      y{0};
+        int                      mipmaps{0};
 
-    bool hasNotChanged(nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, int, int, int);
-};
+        bool has_not_changed(nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, int, int, int);
+    };
 
-struct NRE_GLES2_VertexArray {
-    GLuint                                     handle;
-    std::vector<nre::gpu::vertex_layout_input> layout;
-};
+    struct vertex_array_t {
+        GLuint                                     handle;
+        std::vector<nre::gpu::vertex_layout_input> layout;
+    };
 
-struct NRE_GLES2_ProgramUniformState {
-    GLint  slot{0};
-    GLenum type{GL_FLOAT}; // unused in Uniform blocks
-    size_t size{0};        // unused in Uniform Blocks
-    bool   checked{false}; // used to speed up sanity checks
-};
+    struct program_uniform_state_t {
+        GLint  slot{0};
+        GLenum type{GL_FLOAT}; // unused in Uniform blocks
+        size_t size{0};        // unused in Uniform Blocks
+        bool   checked{false}; // used to speed up sanity checks
+    };
 
-struct NRE_GLES2_Program {
+    struct program_data_t {
+        bool                                                     checked{false};
+        GLuint                                                   handle{0};
+        std::unordered_map<std::string, program_uniform_state_t> uniforms;
+        bool                                                     has_uniform(const std::string&);
+    };
 
-    nre::gpu::vertex_shader_t vs;
-    GLuint                    vs_handle{0};
-    bool                      vs_setup{false};
+    struct program_t {
 
-    nre::gpu::pixel_shader_t fs;
-    GLuint                   fs_handle{0};
-    bool                     fs_setup{false};
+        nre::gpu::vertex_shader_t vs;
+        GLuint                    vs_handle{0};
+        bool                      vs_setup{false};
 
-    bool   setup{false};
-    bool   prog_created{false};
-    GLuint handle{0};
+        nre::gpu::pixel_shader_t fs;
+        GLuint                   fs_handle{0};
+        bool                     fs_setup{false};
 
-    // this is needed for it to be in an std::unordered_set
-    bool   operator==(const NRE_GLES2_Program&) const;
-    size_t gen_hash() const;
-};
+        bool   setup{false};
+        bool   prog_created{false};
+        GLuint handle{0};
+
+        // this is needed for it to be in an std::unordered_set
+        bool   operator==(const program_t&) const;
+        size_t gen_hash() const;
+    };
+}; }; // namespace nre::gles2
 
 namespace std {
     template <>
-    struct hash<NRE_GLES2_Program> {
-        auto operator()(const NRE_GLES2_Program& xyz) const -> size_t {
+    struct hash<nre::gles2::program_t> {
+        auto operator()(const nre::gles2::program_t& xyz) const -> size_t {
             return hash<size_t>{}(xyz.gen_hash());
         }
     };
 } // namespace std
 
-struct NRE_GLES2_ProgramData {
-    bool                                                           checked{false};
-    GLuint                                                         handle{0};
-    std::unordered_map<std::string, NRE_GLES2_ProgramUniformState> uniforms;
-    std::size_t                                                    hasUniform(std::string);
-};
+namespace nre { namespace gles2 {
 
-GLenum NRE2GLES2_BufferUse(nre::gpu::BUFFER_USAGE usage);
+    GLenum buffer_use(nre::gpu::BUFFER_USAGE usage);
 
-class NRE_GLES2_API {
-public:
-    NRE_GLES2_API(nre::gpu::info_struct&);
-    ~NRE_GLES2_API();
+    class api_t {
+    public:
+        api_t(nre::gpu::info_struct&);
+        ~api_t();
 
-    void update(uint32_t, uint32_t);
+        void update(uint32_t, uint32_t);
 
-    void destroy();
+        void destroy();
 
-    std::string getRenderingAPI();
+        std::string get_rendering_api();
 
-    std::size_t newVertexBuffer();
-    std::size_t newVertexLayout();
-    std::size_t newIndexBuffer();
-    std::size_t newProgram();
-    std::size_t newFrameBuffer();
-    std::size_t newTexture();
-    std::size_t newRenderBuffer();
+        std::size_t new_vertex_buffer();
+        std::size_t new_vertex_layout();
+        std::size_t new_index_buffer();
+        std::size_t new_program();
+        std::size_t new_framebuffer();
+        std::size_t new_texture();
+        std::size_t new_renderbuffer();
 
-    void setRenderBufferType(std::size_t, nre::gpu::TEXTURE_TYPE, int, int);
-    void setFrameBufferRenderBuffer(std::size_t, std::size_t, int);
+        void set_renderbuffer_textype(std::size_t, nre::gpu::TEXTURE_TYPE, int, int);
+        void set_framebuffer_renderbuffer(std::size_t, std::size_t, int);
 
-    void setVertexBufferMemory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
-    void setVertexBufferData(std::size_t, const std::vector<float>&, std::size_t);
-    void setVertexBufferMemoryData(std::size_t, const std::vector<float>&, nre::gpu::BUFFER_USAGE);
-    void deleteVertexBuffer(std::size_t);
+        void set_vertex_buffer_memory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
+        void set_vertex_buffer_data(std::size_t, const std::vector<float>&, std::size_t);
+        void set_vertex_buffer_memory_data(std::size_t, const std::vector<float>&, nre::gpu::BUFFER_USAGE);
+        void delete_vertex_buffer(std::size_t);
 
-    void setIndexBufferMemory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
-    void setIndexBufferData(std::size_t, const std::vector<uint32_t>&, std::size_t);
-    void setIndexBufferMemoryData(std::size_t, const std::vector<uint32_t>&, nre::gpu::BUFFER_USAGE);
-    void deleteIndexBuffer(std::size_t);
+        void set_index_buffer_memory(std::size_t, std::size_t, nre::gpu::BUFFER_USAGE);
+        void set_index_buffer_data(std::size_t, const std::vector<uint32_t>&, std::size_t);
+        void set_index_buffer_memory_data(std::size_t, const std::vector<uint32_t>&, nre::gpu::BUFFER_USAGE);
+        void delete_index_buffer(std::size_t);
 
-    void setProgramTextureSlot(std::size_t, std::string, int);
-    void setProgramUniformData(std::size_t, std::string, uint32_t);
-    void setProgramUniformData(std::size_t, std::string, float);
-    void setProgramUniformData(std::size_t, std::string, const std::vector<float>&);
-    int  getProgramUniformSlot(std::size_t, std::string);
+        void set_program_texture_slot(std::size_t, const std::string&, int);
+        void set_program_uniform_data(std::size_t, const std::string&, uint32_t);
+        void set_program_uniform_data(std::size_t, const std::string&, float);
+        void set_program_uniform_data(std::size_t, const std::string&, const std::vector<float>&);
+        int  get_program_uniform_slot(std::size_t, const std::string&);
 
-    void setVertexLayoutFormat(std::size_t, std::vector<nre::gpu::vertex_layout_input>);
-    void deleteVertexLayout(std::size_t);
+        void set_vertex_layout_format(std::size_t, std::vector<nre::gpu::vertex_layout_input>);
+        void delete_vertex_layout(std::size_t);
 
-    void setTextureFormat(std::size_t, nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, uint32_t, uint32_t, int);
-    void setFrameBufferTexture(std::size_t, std::size_t, int);
-    void setTextureSlot(std::size_t, int);
-    void deleteTexture(std::size_t);
+        void set_texture_format(std::size_t, nre::gpu::TEXTURE_TYPE, nre::gpu::TEXTURE_FILTER, uint32_t, uint32_t, int);
+        void set_framebuffer_texture(std::size_t, std::size_t, int);
+        void set_texture_slot(std::size_t, int);
+        void delete_texture(std::size_t);
 
-    void copyFrameBuffer(std::size_t, std::size_t, nre::gpu::FRAMEBUFFER_COPY);
-    void useFrameBuffer(std::size_t);
-    void clearFrameBuffer(std::size_t, nre::gpu::FRAMEBUFFER_COPY, float);
-    void deleteFrameBuffer(std::size_t);
+        void copy_framebuffer(std::size_t, std::size_t, nre::gpu::FRAMEBUFFER_COPY);
+        void use_framebuffer(std::size_t);
+        void clear_framebuffer(std::size_t, nre::gpu::FRAMEBUFFER_COPY, float);
+        void delete_framebuffer(std::size_t);
 
-    void setProgramVS(std::size_t, nre::gpu::vertex_shader_t);
-    void setProgramFS(std::size_t, nre::gpu::pixel_shader_t);
+        void set_program_vs(std::size_t, nre::gpu::vertex_shader_t);
+        void set_program_fs(std::size_t, nre::gpu::pixel_shader_t);
 
-    void setProgramVS(std::size_t, std::string);
-    // void setProgramGS(std::size_t, FE_GPU_Shader);
-    void setProgramFS(std::size_t, std::string);
-    // void setProgramTCS(std::size_t, FE_GPU_Shader);
-    // void setProgramTES(std::size_t, FE_GPU_Shader);
-    void setupProgram(std::size_t);
-    void deleteProgram(std::size_t);
+        void set_program_vs(std::size_t, std::string);
+        // void set_program_gs(std::size_t, FE_GPU_Shader);
+        void set_program_fs(std::size_t, std::string);
+        // void set_program_tcs(std::size_t, FE_GPU_Shader);
+        // void set_program_tes(std::size_t, FE_GPU_Shader);
+        void setup_program(std::size_t);
+        void delete_program(std::size_t);
 
-    void draw(nre::gpu::draw_call);
+        void draw(nre::gpu::draw_call);
 
-    void setRenderMode(nre::gpu::RENDERMODE);
-    void use_wireframe(bool);
+        void set_render_mode(nre::gpu::RENDERMODE);
+        void use_wireframe(bool);
 
-protected:
-    std::size_t cur_rbo{0};
-    std::size_t cur_vbo{0};
-    std::size_t cur_ibo{0};
-    std::size_t cur_vao{0};
-    std::size_t cur_fbo{0};
-    std::size_t cur_texture{0};
-    std::size_t cur_prog{0};
+    protected:
+        std::size_t cur_rbo_{0};
+        std::size_t cur_vbo_{0};
+        std::size_t cur_ibo_{0};
+        std::size_t cur_vao_{0};
+        std::size_t cur_fbo_{0};
+        std::size_t cur_texture_{0};
+        std::size_t cur_prog_{0};
 
-    std::size_t enabled_vao_attribs{0};
+        std::size_t enabled_vao_attribs_{0};
 
-    std::unordered_map<std::size_t, NRE_GLES2_RenderBuffer> rbos;
-    std::unordered_map<std::size_t, NRE_GLES2_VertexBuffer> vbos;
-    std::unordered_map<std::size_t, NRE_GLES2_IndexBuffer>  ibos;
-    std::unordered_map<std::size_t, NRE_GLES2_VertexArray>  vaos;
-    std::unordered_map<std::size_t, NRE_GLES2_FrameBuffer>  fbos;
-    std::unordered_map<std::size_t, NRE_GLES2_Texture>      textures;
-    std::unordered_map<std::size_t, NRE_GLES2_Program>      progs;
+        std::unordered_map<std::size_t, renderbuffer_t>  rbos_;
+        std::unordered_map<std::size_t, vertex_buffer_t> vbos_;
+        std::unordered_map<std::size_t, index_buffer_t>  ibos_;
+        std::unordered_map<std::size_t, vertex_array_t>  vaos_;
+        std::unordered_map<std::size_t, framebuffer_t>   fbos_;
+        std::unordered_map<std::size_t, texture_t>       textures_;
+        std::unordered_map<std::size_t, program_t>       progs_;
 
-    std::size_t getVAOSize(std::size_t);
+        std::size_t get_vao_size(std::size_t);
 
-    std::unordered_map<nre::gpu::vertex_shader_t, GLuint>        vs_db;
-    std::unordered_map<nre::gpu::pixel_shader_t, GLuint>         fs_db;
-    std::unordered_map<NRE_GLES2_Program, NRE_GLES2_ProgramData> prog_db;
+        std::unordered_map<nre::gpu::vertex_shader_t, GLuint> vs_db_;
+        std::unordered_map<nre::gpu::pixel_shader_t, GLuint>  fs_db_;
+        std::unordered_map<program_t, program_data_t>         prog_db_;
 
-private:
-    void check_rbo_id_(std::size_t, const std::string&);
-    void check_vbo_id_(std::size_t, const std::string&);
-    void check_ibo_id_(std::size_t, const std::string&);
+    private:
+        void check_rbo_id(std::size_t, const std::string&);
+        void check_vbo_id(std::size_t, const std::string&);
+        void check_ibo_id(std::size_t, const std::string&);
 
-    void check_vbo_offset_length_(std::size_t, std::size_t, const std::string&);
-    void check_ibo_offset_length_(std::size_t, std::size_t, const std::string&);
+        void check_vbo_offset_length(std::size_t, std::size_t, const std::string&);
+        void check_ibo_offset_length(std::size_t, std::size_t, const std::string&);
 
-    void check_vao_id_(std::size_t, const std::string&);
-    void check_prog_id_(std::size_t, const std::string&);
-    void check_prog_complete_(std::size_t, const std::string&);
+        void check_vao_id(std::size_t, const std::string&);
+        void check_prog_id(std::size_t, const std::string&);
+        void check_prog_complete(std::size_t, const std::string&);
 
-    void check_prog_uniform_block_(std::size_t, const std::string&, const std::string&);
-    void check_prog_uniform_(std::size_t, const std::string&, const std::string&);
-    void check_prog_uniform_property_(std::size_t, const std::string&, std::size_t, const std::string&, bool);
-    void check_vao_vbo_(std::size_t, std::size_t, const std::string&);
+        void check_prog_uniform_block(std::size_t, const std::string&, const std::string&);
+        void check_prog_uniform(std::size_t, const std::string&, const std::string&);
+        void check_prog_uniform_property(std::size_t, const std::string&, std::size_t, const std::string&, bool);
+        void check_vao_vbo(std::size_t, std::size_t, const std::string&);
 
-    void check_fbo_id_(std::size_t, const std::string&);
-    void check_texture_id_(std::size_t, const std::string&);
-    void check_draw_range_(std::size_t, std::size_t, std::size_t, std::size_t, const std::string&);
+        void check_fbo_id(std::size_t, const std::string&);
+        void check_texture_id(std::size_t, const std::string&);
+        void check_draw_range(std::size_t, std::size_t, std::size_t, std::size_t, const std::string&);
 
-    void get_program_all_uniforms_(std::size_t);
+        void get_program_all_uniforms(std::size_t);
 
-    int teximage_internalformat_(nre::gpu::TEXTURE_TYPE);
-    int teximage_format_(nre::gpu::TEXTURE_TYPE);
-    int teximage_type_(nre::gpu::TEXTURE_TYPE);
+        int teximage_internalformat(nre::gpu::TEXTURE_TYPE);
+        int teximage_format(nre::gpu::TEXTURE_TYPE);
+        int teximage_textype(nre::gpu::TEXTURE_TYPE);
 
-    // this is useful for preventing OpenGL glBind* command repetitions
-    GLuint active_vbo_{0};
-    GLuint active_vao_{0};
-    GLuint active_prog_{0};
-    // every VAO in OpenGL stores its Index Buffer
-    std::unordered_map<GLuint, GLuint> vao_ibos_;
+        // this is useful for preventing OpenGL glBind* command repetitions
+        GLuint active_vbo_{0};
+        GLuint active_vao_{0};
+        GLuint active_prog_{0};
+        // every VAO in OpenGL stores its Index Buffer
+        std::unordered_map<GLuint, GLuint> vao_ibos_;
 
-    /// opengl es extensions
-    bool has_oes_packed_depth_stencil{false};
-    bool has_oes_depth24{false};
-    bool has_oes_depth_texture{false}; // webgl_depth_texture
-    bool has_ext_color_buffer_float{false};
-    bool has_ext_color_buffer_half_float{false};
-    bool has_oes_element_index_uint{false};
-    bool has_oes_texture_float{false};
-    bool has_oes_texture_float_linear{false};
-    bool has_oes_texture_half_float{false};
-    bool has_oes_texture_half_float_linear{false};
-    bool has_ext_blend_minmax{false};
-    bool has_ext_texture_filter_anisotropic{false};
-    bool has_oes_texture_npot{false};
-    bool has_ext_texture_compression_s3tc{false}; // WEBGL_compressed_texture_s3tc
-    bool has_ext_srgb{false};
+        /// opengl es extensions
+        bool has_oes_packed_depth_stencil_{false};
+        bool has_oes_depth24_{false};
+        bool has_oes_depth_texture_{false}; // webgl_depth_texture
+        bool has_ext_color_buffer_float_{false};
+        bool has_ext_color_buffer_half_float_{false};
+        bool has_oes_element_index_uint_{false};
+        bool has_oes_texture_float_{false};
+        bool has_oes_texture_float_linear_{false};
+        bool has_oes_texture_half_float_{false};
+        bool has_oes_texture_half_float_linear_{false};
+        bool has_ext_blend_minmax_{false};
+        bool has_ext_texture_filter_anisotropic_{false};
+        bool has_oes_texture_npot_{false};
+        bool has_ext_texture_compression_s3tc_{false}; // WEBGL_compressed_texture_s3tc
+        bool has_ext_srgb_{false};
 
-    uint32_t x_{0};
-    uint32_t y_{0};
-    int      major_{2};
-    int      minor_{0};
-};
-
+        uint32_t x_{0};
+        uint32_t y_{0};
+        int      major_{2};
+        int      minor_{0};
+    };
+}; }; // namespace nre::gles2
 #endif

--- a/include/OE/Renderer/GLES2/api_gles2.h
+++ b/include/OE/Renderer/GLES2/api_gles2.h
@@ -105,7 +105,7 @@ namespace nre { namespace gles2 {
         api_t(nre::gpu::info_struct&);
         ~api_t();
 
-        void update(uint32_t, uint32_t);
+        void update(uint32_t, uint32_t, bool);
 
         void destroy();
 
@@ -247,6 +247,7 @@ namespace nre { namespace gles2 {
         uint32_t y_{0};
         int      major_{2};
         int      minor_{0};
+        bool     sanity_checks_{true};
     };
 }; }; // namespace nre::gles2
 #endif

--- a/include/OE/Renderer/GLES2/api_gles2.h
+++ b/include/OE/Renderer/GLES2/api_gles2.h
@@ -161,6 +161,7 @@ public:
     void draw(nre::gpu::draw_call);
 
     void setRenderMode(nre::gpu::RENDERMODE);
+    void use_wireframe(bool);
 
 protected:
     std::size_t cur_rbo{0};
@@ -237,6 +238,9 @@ private:
     bool has_oes_texture_npot{false};
     bool has_ext_texture_compression_s3tc{false}; // WEBGL_compressed_texture_s3tc
     bool has_ext_srgb{false};
+
+    uint32_t x_{0};
+    uint32_t y_{0};
 };
 
 #endif

--- a/include/OE/Renderer/GLES2/shaders_gles2.h
+++ b/include/OE/Renderer/GLES2/shaders_gles2.h
@@ -3,8 +3,9 @@
 
 #include <OE/Renderer/shaders_gpu.h>
 
-
-std::string NRE_GenGLES2VertexShader(nre::gpu::vertex_shader);
-std::string NRE_GenGLES2PixelShader(nre::gpu::pixel_shader);
+namespace nre { namespace gles2 {
+    std::string gen_vertex_shader(nre::gpu::vertex_shader_t);
+    std::string gen_pixel_shader(nre::gpu::pixel_shader_t);
+}; }; // namespace nre::gles2
 
 #endif

--- a/include/OE/Renderer/api_gpu.h
+++ b/include/OE/Renderer/api_gpu.h
@@ -84,8 +84,10 @@ namespace nre { namespace gpu {
     info_struct    get_backend_info();
     SHADER_BACKEND get_api();
 
-    std::string get_underlying_api_name();
+    int get_minor_api_version();
+    int get_major_api_version();
 
+    std::string get_underlying_api_name();
 
     std::size_t new_vertex_buf();
     std::size_t new_program();
@@ -146,8 +148,8 @@ namespace nre { namespace gpu {
     void clear_framebuffer(std::size_t, nre::gpu::FRAMEBUFFER_COPY, float);
     void del_framebuffer(std::size_t);
 
-    void set_program_vertex_shader(std::size_t, nre::gpu::vertex_shader);
-    void set_program_pixel_shader(std::size_t, nre::gpu::pixel_shader);
+    void set_program_vertex_shader(std::size_t, nre::gpu::vertex_shader_t);
+    void set_program_pixel_shader(std::size_t, nre::gpu::pixel_shader_t);
     void setup_program(std::size_t);
     void del_program(std::size_t);
 

--- a/include/OE/Renderer/api_gpu.h
+++ b/include/OE/Renderer/api_gpu.h
@@ -99,7 +99,7 @@ namespace nre { namespace gpu {
     std::size_t new_renderbuffer();
 
     bool init(SHADER_BACKEND, int, int);
-    void update(uint32_t, uint32_t);
+    void update(uint32_t, uint32_t, bool);
     void destroy();
 
     void set_renderbuffer_textype(std::size_t, TEXTURE_TYPE, int, int);

--- a/include/OE/Renderer/api_gpu.h
+++ b/include/OE/Renderer/api_gpu.h
@@ -102,7 +102,7 @@ namespace nre { namespace gpu {
     void update(uint32_t, uint32_t);
     void destroy();
 
-    void set_renderbuffer_mode(std::size_t, TEXTURE_TYPE, int, int);
+    void set_renderbuffer_textype(std::size_t, TEXTURE_TYPE, int, int);
     void set_framebuffer_renderbuffer(std::size_t, std::size_t, int);
     ;
 
@@ -125,15 +125,15 @@ namespace nre { namespace gpu {
 
     void set_uniform_buf_state(std::size_t, std::size_t, int, std::size_t, std::size_t);
 
-    void set_program_uniform_buf_slot(std::size_t, std::string, int);
-    int  get_program_uniform_buf_slot(std::size_t, std::string);
+    void set_program_uniform_buf_slot(std::size_t, const std::string&, int);
+    int  get_program_uniform_buf_slot(std::size_t, const std::string&);
 
-    void set_program_texture_slot(std::size_t, std::string, int);
-    void set_program_uniform_data(std::size_t, std::string, uint32_t);
-    void set_program_uniform_data(std::size_t, std::string, float);
-    void set_program_uniform_data(std::size_t, std::string, const std::vector<uint32_t>&);
-    void set_program_uniform_data(std::size_t, std::string, const std::vector<float>&);
-    int  get_program_uniform_slot(std::size_t, std::string);
+    void set_program_texture_slot(std::size_t, const std::string&, int);
+    void set_program_uniform_data(std::size_t, const std::string&, uint32_t);
+    void set_program_uniform_data(std::size_t, const std::string&, float);
+    void set_program_uniform_data(std::size_t, const std::string&, const std::vector<uint32_t>&);
+    void set_program_uniform_data(std::size_t, const std::string&, const std::vector<float>&);
+    int  get_program_uniform_slot(std::size_t, const std::string&);
 
     void set_vertex_layout_format(std::size_t, std::vector<vertex_layout_input>);
     void del_vertex_layout(std::size_t);

--- a/include/OE/Renderer/api_gpu.h
+++ b/include/OE/Renderer/api_gpu.h
@@ -77,12 +77,8 @@ namespace nre { namespace gpu {
 
     //////////////////////
     //  all variables here
-    extern void*             api;
-    extern info_struct       backend_info;
-    extern std::atomic<bool> use_wireframe;
-
-    extern uint32_t x;
-    extern uint32_t y;
+    extern void*       api;
+    extern info_struct backend_info;
     //////////////////////
 
     info_struct    get_backend_info();
@@ -162,7 +158,7 @@ namespace nre { namespace gpu {
     void draw_instanced(std::size_t, std::size_t, std::size_t, int);
 
     void set_render_mode(nre::gpu::RENDERMODE);
-
+    void use_wireframe(bool);
 }; }; // namespace nre::gpu
 
 

--- a/include/OE/Renderer/drawcall_container.h
+++ b/include/OE/Renderer/drawcall_container.h
@@ -34,7 +34,7 @@ public:
         friend bool operator!=(const Iterator& a, const Iterator& b);
 
     private:
-        set_iter_t             iter;
+        set_iter_t iter;
     };
 
     Iterator begin();

--- a/include/OE/Renderer/drawcall_container.h
+++ b/include/OE/Renderer/drawcall_container.h
@@ -20,7 +20,7 @@ public:
     public:
         typedef std::set<NRE_RenderGroup>::iterator set_iter_t;
 
-        Iterator(NRE_DrawCallContainer&, set_iter_t);
+        Iterator(set_iter_t);
 
         Iterator&       operator++();
         Iterator        operator++(int);
@@ -35,7 +35,6 @@ public:
 
     private:
         set_iter_t             iter;
-        NRE_DrawCallContainer& db_;
     };
 
     Iterator begin();

--- a/include/OE/Renderer/renderer_legacy.h
+++ b/include/OE/Renderer/renderer_legacy.h
@@ -18,7 +18,7 @@ public:
     void destroy();
 
     // holds all rendering data from the engine
-    NRE_DataHandler data_;
+    nre::data_handler_t data_;
 
     // normal and point light draw calls, framebuffer, integer texture and ubo/program
     std::set<NRE_PointLightDrawCall, std::greater<NRE_PointLightDrawCall>> pt_visible_lights;

--- a/include/OE/Renderer/renderer_legacy.h
+++ b/include/OE/Renderer/renderer_legacy.h
@@ -5,7 +5,7 @@
 #include <OE/Renderer/renderer_utils.h>
 #include <OE/dummy_classes.h>
 
-class NRE_RendererLegacy : public OE_RendererBase {
+class NRE_RendererLegacy : public oe::renderer_base_t {
 public:
     NRE_RendererLegacy();
     ~NRE_RendererLegacy();

--- a/include/OE/Renderer/renderer_legacy.h
+++ b/include/OE/Renderer/renderer_legacy.h
@@ -11,11 +11,11 @@ public:
     ~NRE_RendererLegacy();
 
     bool init(oe::renderer_init_info, oe::renderer_update_info, oe::winsys_output);
-    bool updateSingleThread(oe::renderer_update_info, oe::winsys_output);
+    bool update_single_thread(oe::renderer_update_info, oe::winsys_output);
     // last bool is true if the renderer has been restarted. This is useful so as to fetch all the data again
-    bool updateData(oe::renderer_update_info, oe::winsys_output, bool);
+    bool update_data(oe::renderer_update_info, oe::winsys_output, bool);
 
-    bool updateMultiThread(OE_Task*, int);
+    bool update_multi_thread(OE_Task*, int);
     void destroy();
 
     // holds all rendering data from the engine

--- a/include/OE/Renderer/renderer_legacy.h
+++ b/include/OE/Renderer/renderer_legacy.h
@@ -10,9 +10,10 @@ public:
     NRE_RendererLegacy();
     ~NRE_RendererLegacy();
 
-    bool init();
-    bool updateSingleThread();
-    bool updateData();
+    bool init(oe::renderer_init_info, oe::renderer_update_info, oe::winsys_output);
+    bool updateSingleThread(oe::renderer_update_info, oe::winsys_output);
+    // last bool is true if the renderer has been restarted. This is useful so as to fetch all the data again
+    bool updateData(oe::renderer_update_info, oe::winsys_output, bool);
 
     bool updateMultiThread(OE_Task*, int);
     void destroy();
@@ -79,6 +80,17 @@ protected:
     void updateMaterialGPUData();
     void updateCameraGPUData();
     void updateLightGPUData();
+
+    oe::RENDERER_SHADING_MODE shading_mode{oe::RENDERER_REGULAR_SHADING};
+    bool                      use_wireframe{false};
+    bool                      render_bounding_boxes{false};
+    bool                      render_bounding_spheres{false};
+    bool                      use_HDR{false};
+    bool                      use_z_prepass{false};
+
+    int                    res_x_{0};
+    int                    res_y_{0};
+    oe::renderer_init_info init_info;
 };
 
 #endif

--- a/include/OE/Renderer/renderer_main.h
+++ b/include/OE/Renderer/renderer_main.h
@@ -10,9 +10,10 @@ public:
     NRE_Renderer();
     ~NRE_Renderer();
 
-    bool init();
-    bool updateSingleThread();
-    bool updateData();
+    bool init(oe::renderer_init_info, oe::renderer_update_info, oe::winsys_output);
+    bool updateSingleThread(oe::renderer_update_info, oe::winsys_output);
+    // last bool is true if the renderer has been restarted. This is useful so as to fetch all the data again
+    bool updateData(oe::renderer_update_info, oe::winsys_output, bool);
 
     bool updateMultiThread(OE_Task*, int);
     void destroy();
@@ -80,6 +81,17 @@ protected:
     void updateMaterialGPUData();
     void updateCameraGPUData();
     void updateLightGPUData();
+
+    oe::RENDERER_SHADING_MODE shading_mode{oe::RENDERER_REGULAR_SHADING};
+    bool                      use_wireframe{false};
+    bool                      render_bounding_boxes{false};
+    bool                      render_bounding_spheres{false};
+    bool                      use_HDR{false};
+    bool                      use_z_prepass{false};
+
+    int                    res_x_{0};
+    int                    res_y_{0};
+    oe::renderer_init_info init_info;
 };
 
 #endif

--- a/include/OE/Renderer/renderer_main.h
+++ b/include/OE/Renderer/renderer_main.h
@@ -11,11 +11,11 @@ public:
     ~NRE_Renderer();
 
     bool init(oe::renderer_init_info, oe::renderer_update_info, oe::winsys_output);
-    bool updateSingleThread(oe::renderer_update_info, oe::winsys_output);
+    bool update_single_thread(oe::renderer_update_info, oe::winsys_output);
     // last bool is true if the renderer has been restarted. This is useful so as to fetch all the data again
-    bool updateData(oe::renderer_update_info, oe::winsys_output, bool);
+    bool update_data(oe::renderer_update_info, oe::winsys_output, bool);
 
-    bool updateMultiThread(OE_Task*, int);
+    bool update_multi_thread(OE_Task*, int);
     void destroy();
 
     // holds all rendering data from the engine

--- a/include/OE/Renderer/renderer_main.h
+++ b/include/OE/Renderer/renderer_main.h
@@ -5,7 +5,7 @@
 #include <OE/Renderer/renderer_utils.h>
 #include <OE/dummy_classes.h>
 
-class NRE_Renderer : public OE_RendererBase {
+class NRE_Renderer : public oe::renderer_base_t {
 public:
     NRE_Renderer();
     ~NRE_Renderer();

--- a/include/OE/Renderer/renderer_main.h
+++ b/include/OE/Renderer/renderer_main.h
@@ -18,7 +18,8 @@ public:
     void destroy();
 
     // holds all rendering data from the engine
-    NRE_DataHandler data_;
+    nre::data_handler_t data_;
+
 
     // normal and point light draw calls, framebuffer, integer texture and ubo/program
     std::set<NRE_PointLightDrawCall, std::greater<NRE_PointLightDrawCall>> pt_visible_lights;

--- a/include/OE/Renderer/renderer_utils.h
+++ b/include/OE/Renderer/renderer_utils.h
@@ -6,15 +6,15 @@
 struct NRE_RenderGroup {
 
     // data for the z prepass
-    nre::gpu::vertex_shader vs_z_prepass;
-    std::size_t             z_prepass_program{0};
-    bool                    isZPrePassSetup{false};
+    nre::gpu::vertex_shader_t vs_z_prepass;
+    std::size_t               z_prepass_program{0};
+    bool                      isZPrePassSetup{false};
 
     // data for normal render
-    nre::gpu::vertex_shader vs;
-    nre::gpu::pixel_shader  fs;
-    std::size_t             program{0};
-    bool                    isSetup{false};
+    nre::gpu::vertex_shader_t vs;
+    nre::gpu::pixel_shader_t  fs;
+    std::size_t               program{0};
+    bool                      isSetup{false};
 
     // draw call data
     std::size_t camera{0};

--- a/include/OE/Renderer/shaders_gpu.h
+++ b/include/OE/Renderer/shaders_gpu.h
@@ -31,23 +31,21 @@ namespace nre { namespace gpu {
         FS_LIGHT_INDEX
     };
 
-    class shader_base {
+    std::string gen_shader_prefix();
+
+    class shader_base_t {
     public:
-        static std::string shader_prefix;
-
-        static void init(SHADER_BACKEND, int, int);
-
-        virtual ~shader_base();
+        virtual ~shader_base_t();
         virtual std::string gen_shader() const;
         virtual std::string info() const;
     };
 
-    class vertex_shader : public shader_base {
+    class vertex_shader_t : public shader_base_t {
     public:
-        vertex_shader();
-        ~vertex_shader();
+        vertex_shader_t();
+        ~vertex_shader_t();
 
-        bool operator==(const vertex_shader&) const;
+        bool operator==(const vertex_shader_t&) const;
 
         std::string gen_shader() const;
         std::string info() const;
@@ -58,12 +56,12 @@ namespace nre { namespace gpu {
         VS_TYPE     type{VS_UNDEFINED};
     };
 
-    class pixel_shader : public shader_base {
+    class pixel_shader_t : public shader_base_t {
     public:
-        pixel_shader();
-        ~pixel_shader();
+        pixel_shader_t();
+        ~pixel_shader_t();
 
-        bool operator==(const pixel_shader&) const;
+        bool operator==(const pixel_shader_t&) const;
 
         std::string gen_shader() const;
         std::string info() const;
@@ -80,8 +78,8 @@ namespace nre { namespace gpu {
 
 namespace std {
     template <>
-    struct hash<nre::gpu::vertex_shader> {
-        auto operator()(const nre::gpu::vertex_shader& xyz) const -> size_t {
+    struct hash<nre::gpu::vertex_shader_t> {
+        auto operator()(const nre::gpu::vertex_shader_t& xyz) const -> size_t {
             return hash<size_t>{}(xyz.gen_hash());
         }
     };
@@ -89,8 +87,8 @@ namespace std {
 
 namespace std {
     template <>
-    struct hash<nre::gpu::pixel_shader> {
-        auto operator()(const nre::gpu::pixel_shader& xyz) const -> size_t {
+    struct hash<nre::gpu::pixel_shader_t> {
+        auto operator()(const nre::gpu::pixel_shader_t& xyz) const -> size_t {
             return hash<size_t>{}(xyz.gen_hash());
         }
     };

--- a/include/OE/Renderer/shaders_gpu.h
+++ b/include/OE/Renderer/shaders_gpu.h
@@ -47,11 +47,11 @@ namespace nre { namespace gpu {
         vertex_shader();
         ~vertex_shader();
 
-        bool operator<(const vertex_shader&) const;
         bool operator==(const vertex_shader&) const;
 
-        std::string gen_shader();
-        std::string info();
+        std::string gen_shader() const;
+        std::string info() const;
+        size_t      gen_hash() const;
 
         bool        fullscreenQuad{false};
         std::size_t num_of_uvs{0};
@@ -63,14 +63,37 @@ namespace nre { namespace gpu {
         pixel_shader();
         ~pixel_shader();
 
-        bool operator<(const pixel_shader&) const;
+        bool operator==(const pixel_shader&) const;
 
-        std::string gen_shader();
-        std::string info();
+        std::string gen_shader() const;
+        std::string info() const;
+        size_t      gen_hash() const;
 
         std::size_t num_of_uvs{0};
         FS_TYPE     type{FS_UNDEFINED};
     };
 
 }; }; // namespace nre::gpu
+
+
+// specializations for hashing
+
+namespace std {
+template <>
+struct hash<nre::gpu::vertex_shader> {
+  auto operator()(const nre::gpu::vertex_shader &xyz) const -> size_t {
+    return hash<size_t>{}(xyz.gen_hash());
+  }
+};
+}  // namespace std
+
+namespace std {
+template <>
+struct hash<nre::gpu::pixel_shader> {
+  auto operator()(const nre::gpu::pixel_shader &xyz) const -> size_t {
+    return hash<size_t>{}(xyz.gen_hash());
+  }
+};
+}  // namespace std
+
 #endif

--- a/include/OE/Renderer/shaders_gpu.h
+++ b/include/OE/Renderer/shaders_gpu.h
@@ -38,8 +38,8 @@ namespace nre { namespace gpu {
         static void init(SHADER_BACKEND, int, int);
 
         virtual ~shader_base();
-        virtual std::string gen_shader();
-        virtual std::string info();
+        virtual std::string gen_shader() const;
+        virtual std::string info() const;
     };
 
     class vertex_shader : public shader_base {

--- a/include/OE/Renderer/shaders_gpu.h
+++ b/include/OE/Renderer/shaders_gpu.h
@@ -79,21 +79,21 @@ namespace nre { namespace gpu {
 // specializations for hashing
 
 namespace std {
-template <>
-struct hash<nre::gpu::vertex_shader> {
-  auto operator()(const nre::gpu::vertex_shader &xyz) const -> size_t {
-    return hash<size_t>{}(xyz.gen_hash());
-  }
-};
-}  // namespace std
+    template <>
+    struct hash<nre::gpu::vertex_shader> {
+        auto operator()(const nre::gpu::vertex_shader& xyz) const -> size_t {
+            return hash<size_t>{}(xyz.gen_hash());
+        }
+    };
+} // namespace std
 
 namespace std {
-template <>
-struct hash<nre::gpu::pixel_shader> {
-  auto operator()(const nre::gpu::pixel_shader &xyz) const -> size_t {
-    return hash<size_t>{}(xyz.gen_hash());
-  }
-};
-}  // namespace std
+    template <>
+    struct hash<nre::gpu::pixel_shader> {
+        auto operator()(const nre::gpu::pixel_shader& xyz) const -> size_t {
+            return hash<size_t>{}(xyz.gen_hash());
+        }
+    };
+} // namespace std
 
 #endif

--- a/include/OE/Renderer/shaders_gpu.h
+++ b/include/OE/Renderer/shaders_gpu.h
@@ -10,7 +10,7 @@ namespace nre { namespace gpu {
     // possibility to extend with HLSL/Metal etc.
     enum SHADER_BACKEND : int { UNDEFINED, GL, GLES, GLES2 };
 
-    enum VS_TYPE {
+    enum VS_TYPE : uint8_t {
         VS_UNDEFINED,
         VS_Z_PREPASS,
         VS_REGULAR,
@@ -19,7 +19,7 @@ namespace nre { namespace gpu {
         VS_LIGHT,
     };
 
-    enum FS_TYPE {
+    enum FS_TYPE : uint8_t {
         FS_UNDEFINED,
         FS_SIMPLE,
         FS_GAMMA,

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -46,7 +46,7 @@ namespace oe {
 
     // enum typedefs
 
-    typedef OE_METHOD    method_type;
+    typedef OE_METHOD method_type;
 
     namespace os {
         typedef OE_OS type;

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -58,6 +58,7 @@ namespace oe {
         extern oe::networking_init_info networking_parameters;
 
         void request_gles2();
+        void request_gles31();
     }; // namespace preinit
 
     /** Basic API functions for starting the Oxygen Engine

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -410,9 +410,13 @@ namespace oe {
     void render_bounding_spheres(bool);
     void toggle_bounding_spheres_rendering();
 
-    // These two do not require a call to OE_RestartRenderer
     void render_HDR(bool);
     void toggle_render_HDR();
+
+
+    // Debug options
+    void set_renderer_sanity_checks(bool);
+    void toggle_renderer_sanity_checks();
 
     /** API functions to control the window system
      *  These should work for ANY window system

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -240,7 +240,7 @@ namespace oe {
         assert(OE_Main != nullptr);
         oe::event_func_type func_copy =
             std::bind(func, std::placeholders::_1, std::placeholders::_2, std::forward<Args...>(arguments...));
-        OE_Main->window->event_handler.setIEventFunc(name, func_copy);
+        OE_Main->window->event_handler_.set_ievent_func(name, func_copy);
     }
 
     template <typename T>
@@ -248,7 +248,7 @@ namespace oe {
 
         assert(OE_Main != nullptr);
         oe::event_func_type func_copy = std::bind(func, std::placeholders::_1, std::placeholders::_2);
-        OE_Main->window->event_handler.setIEventFunc(name, func_copy);
+        OE_Main->window->event_handler_.set_ievent_func(name, func_copy);
     }
 
     template <typename T, typename A, typename... Args>
@@ -257,7 +257,7 @@ namespace oe {
         assert(OE_Main != nullptr);
         oe::event_func_type func_copy =
             std::bind(func, instance, std::placeholders::_1, std::placeholders::_2, std::forward<Args...>(arguments...));
-        OE_Main->window->event_handler.setIEventFunc(name, func_copy);
+        OE_Main->window->event_handler_.set_ievent_func(name, func_copy);
     }
 
     template <typename T, typename A>
@@ -265,7 +265,7 @@ namespace oe {
 
         assert(OE_Main != nullptr);
         oe::event_func_type func_copy = std::bind(func, instance, std::placeholders::_1, std::placeholders::_2);
-        OE_Main->window->event_handler.setIEventFunc(name, func_copy);
+        OE_Main->window->event_handler_.set_ievent_func(name, func_copy);
     }
 
     void destroy_event(std::string);

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -52,9 +52,13 @@ namespace oe {
     // API functions to be executed before the engine runs
     namespace preinit {
 
-        extern bool use_legacy_renderer; // default: false
+        extern oe::renderer_init_info   renderer_parameters;
+        extern oe::winsys_init_info     winsys_parameters;
+        extern oe::physics_init_info    physics_parameters;
+        extern oe::networking_init_info networking_parameters;
 
-    };
+        void request_gles2();
+    }; // namespace preinit
 
     /** Basic API functions for starting the Oxygen Engine
      *  and assigning tasks

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -48,29 +48,6 @@ namespace oe {
 
     typedef OE_METHOD method_type;
 
-    namespace os {
-        typedef OE_OS type;
-        const type    undefined = (type)0;
-        const type    linux     = (type)1;
-        const type    windows   = (type)2;
-    }; // namespace os
-
-    namespace winsys {
-        typedef OE_WINSYS type;
-        const type        none           = (type)0;
-        const type        sdl            = (type)1;
-        const type        something_else = (type)2;
-    }; // namespace winsys
-
-    namespace renderer { namespace shading_mode {
-
-        typedef OE_RENDERER_SHADING_MODE type;
-        const type                       normals        = (type)0;
-        const type                       no_light       = (type)1;
-        const type                       dir_lights     = (type)2;
-        const type                       indexed_lights = (type)3;
-        const type                       regular        = (type)4;
-    }; }; // namespace renderer::shading_mode
     //------------------------BLOCK-------------------------//
     // API functions to be executed before the engine runs
     namespace preinit {
@@ -416,9 +393,9 @@ namespace oe {
      * All those parameters require a call to OE_RestartRenderer to take effect
      */
 
-    void                             restart_renderer();
-    void                             set_shading_mode(oe::renderer::shading_mode::type);
-    oe::renderer::shading_mode::type get_shading_mode();
+    void                      restart_renderer();
+    void                      set_shading_mode(oe::RENDERER_SHADING_MODE);
+    oe::RENDERER_SHADING_MODE get_shading_mode();
 
     void render_wireframe(bool);
     void toggle_wireframe_rendering();

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -395,7 +395,6 @@ namespace oe {
 
     /** API functions to control the renderer
      *  These should work for ANY renderer
-     * All those parameters require a call to OE_RestartRenderer to take effect
      */
 
     void                      restart_renderer();
@@ -414,6 +413,16 @@ namespace oe {
     // These two do not require a call to OE_RestartRenderer
     void render_HDR(bool);
     void toggle_render_HDR();
+
+    /** API functions to control the window system
+     *  These should work for ANY window system
+     */
+    void        set_window_title(std::string title);
+    std::string get_window_title();
+
+    // not functional yet
+    void toggle_window_fullscreen();
+    void set_window_fullscreen(bool);
 }; // namespace oe
 
 

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -47,7 +47,6 @@ namespace oe {
     // enum typedefs
 
     typedef OE_METHOD    method_type;
-    typedef OE_EVENTFUNC event_func_type;
 
     namespace os {
         typedef OE_OS type;

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -98,6 +98,10 @@ namespace oe {
         bool                  render_bounding_spheres{false};
         bool                  use_z_prepass{true};
         RENDERER_SHADING_MODE shading_mode{RENDERER_REGULAR_SHADING};
+
+        /// Without sanity checks the renderer may segfault or silently fail without warning or error messages
+        /// Tradeoff: Higher performance
+        bool sanity_checks{true};
     };
 
     class renderer_base_t : public OE_THREAD_SAFETY_OBJECT {

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -135,7 +135,7 @@ namespace oe {
 
         virtual bool init(physics_init_info);
 
-        virtual void update_info(physics_update_info);
+        virtual void update_info(physics_update_info) noexcept;
         virtual bool update_multi_thread(OE_Task*, int);
         virtual void destroy();
 

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -60,7 +60,7 @@ public:
     std::atomic<bool> restart_renderer{false};
 
     // The global event handler is here and must be initialized in all sub classes
-    oe::event_handler_t event_handler;
+    oe::event_handler_t event_handler_;
 };
 
 /** This is a dummy class aimed to be a base class for

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -2,130 +2,188 @@
 #define OE_DUMMYCLASSES_H
 
 #include <OE/Events/event_handler.h>
+#include <OE/Renderer/api_gpu.h>
 #include <OE/task.h>
 #include <OE/types/base_types.h>
 #include <OE/types/world.h>
 
+namespace oe {
+
+    enum OS : int { OS_UNDEFINED = 0, OS_LINUX = 1, OS_WINDOWS = 2, OS_ANDROID = 3, OS_WEB = 4 };
+
+    enum WINSYS : int { WINSYS_NONE = 0, WINSYS_SDL = 1, WINSYS_SOMETHING_ELSE = 2 };
+
+    enum RENDERER_SHADING_MODE : int {
+        RENDERER_NORMALS_SHADING        = 0,
+        RENDERER_NO_LIGHTS_SHADING      = 1,
+        RENDERER_DIR_LIGHTS_SHADING     = 2,
+        RENDERER_INDEXED_LIGHTS_SHADING = 3,
+        RENDERER_REGULAR_SHADING        = 4
+    };
+
+    /** This a dummy class aimed to be used as a base class for windowing systems
+     * Plus relevant structs for getting info in and out
+     */
+
+    // initial parameters
+    struct winsys_init_info {
+        nre::gpu::SHADER_BACKEND requested_backend{nre::gpu::GLES2};
+    };
+
+    // dynamic parameters
+    struct winsys_update_info {
+        std::string title;
+        int         res_x{640};
+        int         res_y{480};
+        bool        use_fullscreen{false};
+        bool        vsync{true};
+        bool        mouse_locked{true};
+    };
+
+    // output to the renderer
+    struct winsys_output {
+        int                      res_x{640};
+        int                      res_y{480};
+        nre::gpu::SHADER_BACKEND backend{nre::gpu::GLES2};
+        int                      major{2};
+        int                      minor{0};
+        bool                     restart_renderer{false};
+        bool                     done{false};
+        int                      dpi{96};
+    };
+
+    class winsys_base_t : public OE_THREAD_SAFETY_OBJECT {
+    public:
+        winsys_base_t();
+        virtual ~winsys_base_t();
 
 
-enum OE_OS : int { OE_UNDEFINED = 0, OE_LINUX = 1, OE_WINDOWS = 2, OE_ANDROID = 2 };
+        virtual bool init(int, int, std::string, bool, bool, void*);
+        virtual bool update();
 
-enum OE_WINSYS : int { OE_NONE = 0, OE_SDL = 1, OE_SOMETHING_ELSE = 2 };
+        virtual bool getMouseLockedState();
+        virtual void lockMouse();
+        virtual void unlockMouse();
 
-enum OE_RENDERER_SHADING_MODE : int {
-    OE_RENDERER_NORMALS_SHADING        = 0,
-    OE_RENDERER_NO_LIGHTS_SHADING      = 1,
-    OE_RENDERER_DIR_LIGHTS_SHADING     = 2,
-    OE_RENDERER_INDEXED_LIGHTS_SHADING = 3,
-    OE_RENDERER_REGULAR_SHADING        = 4
-};
+        virtual bool updateEvents();
+        virtual void destroy();
 
-/** This a dummy class aimed to be used as a base class for windowing systems
- * It
- */
-class OE_WindowSystemBase : public OE_THREAD_SAFETY_OBJECT {
-public:
-    OE_WindowSystemBase();
-    virtual ~OE_WindowSystemBase();
+        int  resolution_x{0};
+        int  resolution_y{0};
+        int  dpi{96};
+        bool vsync{true};
 
+        OS     os{OS_UNDEFINED};
+        WINSYS winsys{WINSYS_NONE};
 
-    virtual bool init(int, int, std::string, bool, bool, void*);
-    virtual bool update();
+        // For different OpenGL versions
+        std::string title;
+        bool        fullscreen{false};
+        int         major{0};
+        int         minor{0};
+        bool        isES{false};
 
-    virtual bool getMouseLockedState();
-    virtual void lockMouse();
-    virtual void unlockMouse();
+        bool mouse_locked{false};
 
-    virtual bool updateEvents();
-    virtual void destroy();
+        std::atomic<bool> reset_renderer{false};
+        std::atomic<bool> restart_renderer{false};
 
-    int  resolution_x{0};
-    int  resolution_y{0};
-    int  dpi{96};
-    bool vsync{true};
+        // The global event handler is here and must be initialized in all sub classes
+        oe::event_handler_t event_handler_;
+    };
 
-    OE_OS     os{OE_UNDEFINED};
-    OE_WINSYS winsys{OE_NONE};
+    /** This is a dummy class aimed to be a base class for
+     *  a renderer
+     * plus relevant structs for getting info in and out
+     */
+    // initial parameters
+    struct renderer_init_info {
+        bool some_var{false};
+    };
 
-    // For different OpenGL versions
-    std::string title;
-    bool        fullscreen{false};
-    int         major{0};
-    int         minor{0};
-    bool        isES{false};
+    // dynamic parameters
+    struct renderer_update_info {
+        bool                  use_hdr{false};
+        bool                  use_wireframe{false};
+        bool                  use_light_indexed_rendering{false};
+        bool                  render_bounding_boxes{false};
+        bool                  render_bounding_spheres{false};
+        bool                  use_z_prepass{true};
+        RENDERER_SHADING_MODE shading_mode{RENDERER_REGULAR_SHADING};
+    };
 
-    bool mouse_locked{false};
+    class renderer_base_t : public OE_THREAD_SAFETY_OBJECT {
+    public:
+        renderer_base_t();
+        virtual ~renderer_base_t();
 
-    std::atomic<bool> reset_renderer{false};
-    std::atomic<bool> restart_renderer{false};
+        virtual bool init();
+        virtual bool updateSingleThread();
+        virtual bool updateData();
 
-    // The global event handler is here and must be initialized in all sub classes
-    oe::event_handler_t event_handler_;
-};
+        virtual bool updateMultiThread(OE_Task*, int);
+        virtual void destroy();
 
-/** This is a dummy class aimed to be a base class for
- *  a renderer
- */
-class OE_RendererBase : public OE_THREAD_SAFETY_OBJECT {
-public:
-    OE_RendererBase();
-    virtual ~OE_RendererBase();
+        bool                      isMultiThreaded{false};
+        std::shared_ptr<OE_World> world{nullptr};
+        winsys_base_t*            screen{nullptr};
+        std::string               name{"default"};
 
-    virtual bool init();
-    virtual bool updateSingleThread();
-    virtual bool updateData();
+        RENDERER_SHADING_MODE shading_mode{RENDERER_REGULAR_SHADING};
+        std::atomic<bool>     use_wireframe{false};
+        std::atomic<bool>     render_bounding_boxes{false};
+        std::atomic<bool>     render_bounding_spheres{false};
+        std::atomic<bool>     use_HDR{false};
+    };
 
-    virtual bool updateMultiThread(OE_Task*, int);
-    virtual void destroy();
+    /** This is a dummy class aimed to be a base class for
+     *  a physics engine
+     * plus relevant structs for getting info in and out
+     */
+    // initial parameters
+    struct physics_init_info {
+        bool some_var{false};
+    };
 
-    bool                      isMultiThreaded{false};
-    std::shared_ptr<OE_World> world{nullptr};
-    OE_WindowSystemBase*      screen{nullptr};
-    std::string               name{"default"};
+    // dynamic parameters
+    struct physics_update_info {
+        float gravity{-9.81f};
+    };
 
-    OE_RENDERER_SHADING_MODE shading_mode{OE_RENDERER_REGULAR_SHADING};
-    std::atomic<bool>        use_wireframe{false};
-    std::atomic<bool>        render_bounding_boxes{false};
-    std::atomic<bool>        render_bounding_spheres{false};
-    std::atomic<bool>        use_HDR{false};
-};
+    class physics_base_t : public OE_THREAD_SAFETY_OBJECT {
+    public:
+        physics_base_t();
+        virtual ~physics_base_t();
 
-/** This is a dummy class aimed to be a base class for
- *  a physics engine
- */
-class OE_PhysicsEngineBase : public OE_THREAD_SAFETY_OBJECT {
-public:
-    OE_PhysicsEngineBase();
-    virtual ~OE_PhysicsEngineBase();
+        virtual bool init();
 
-    virtual bool init();
+        virtual bool updateMultiThread(OE_Task*, int);
+        virtual void destroy();
 
-    virtual bool updateMultiThread(OE_Task*, int);
-    virtual void destroy();
+        bool                      isMultiThreaded{false};
+        std::shared_ptr<OE_World> world{nullptr};
+        // You do not actually need this since you can use API functions directly in your
+        // Physics engine .cpp :))
+        // OE_EventHandler*    handler{nullptr};
+        std::string name{"default"};
+    };
 
-    bool                      isMultiThreaded{false};
-    std::shared_ptr<OE_World> world{nullptr};
-    // You do not actually need this since you can use API functions directly in your
-    // Physics engine .cpp :))
-    // OE_EventHandler*    handler{nullptr};
-    std::string name{"default"};
-};
+    /** This is a dummy class aimed to be a base class for
+     *  a netwotking manager
+     * plus relevant structs for getting info in and out
+     */
 
-/** This is a dummy class aimed to be a base class for
- *  a netwotking manager
- */
+    class networking_base_t : public OE_THREAD_SAFETY_OBJECT {
+    public:
+        networking_base_t();
+        virtual ~networking_base_t();
 
-class OE_NetworkingBase : public OE_THREAD_SAFETY_OBJECT {
-public:
-    OE_NetworkingBase();
-    virtual ~OE_NetworkingBase();
+        virtual void init();
+        virtual int  execute(OE_Task);
+        virtual void destroy();
 
-    virtual void init();
-    virtual int  execute(OE_Task);
-    virtual void destroy();
-
-    std::atomic<bool> done{false};
-    std::string       name{"default"};
-};
-
+        std::atomic<bool> done{false};
+        std::string       name{"default"};
+    };
+}; // namespace oe
 #endif

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -102,11 +102,11 @@ namespace oe {
         virtual ~renderer_base_t();
 
         virtual bool init(renderer_init_info, renderer_update_info, winsys_output);
-        virtual bool updateSingleThread(renderer_update_info, winsys_output);
+        virtual bool update_single_thread(renderer_update_info, winsys_output);
         // last bool is true if the renderer has been restarted. This is useful so as to fetch all the data again
-        virtual bool updateData(renderer_update_info, winsys_output, bool);
+        virtual bool update_data(renderer_update_info, winsys_output, bool);
 
-        virtual bool updateMultiThread(OE_Task*, int); // stub for now
+        virtual bool update_multi_thread(OE_Task*, int); // stub for now
         virtual void destroy();
 
         bool                      isMultiThreaded{false};
@@ -136,7 +136,7 @@ namespace oe {
         virtual bool init(physics_init_info);
 
         virtual void update_info(physics_update_info);
-        virtual bool updateMultiThread(OE_Task*, int);
+        virtual bool update_multi_thread(OE_Task*, int);
         virtual void destroy();
 
         bool                      isMultiThreaded{false};

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -60,7 +60,7 @@ public:
     std::atomic<bool> restart_renderer{false};
 
     // The global event handler is here and must be initialized in all sub classes
-    OE_EventHandler event_handler;
+    oe::event_handler_t event_handler;
 };
 
 /** This is a dummy class aimed to be a base class for

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -35,9 +35,13 @@ namespace oe {
         std::string title;
         int         res_x{640};
         int         res_y{480};
-        bool        use_fullscreen{false};
-        bool        vsync{true};
-        bool        mouse_locked{true};
+        bool        changed_resolution{false};
+
+        bool use_fullscreen{false};
+        bool changed_fullscreen{false};
+
+        bool vsync{true};
+        bool mouse_locked{true};
     };
 
     // output to the renderer

--- a/include/OE/error_oe.h
+++ b/include/OE/error_oe.h
@@ -94,6 +94,18 @@ namespace oe {
         std::string data_;
     };
 
+    class winsys_init_failed : public winsys_error {
+    public:
+        winsys_init_failed(std::string arg) {
+            name_ = "oe::winsys_init_failed";
+            data_ = arg;
+        }
+        std::string what() const throw() {
+            return data_;
+        };
+        std::string data_;
+    };
+
 }; // namespace oe
 
 #endif

--- a/include/OE/task_manager.h
+++ b/include/OE/task_manager.h
@@ -109,15 +109,15 @@ public:
 
 
     OE_THREAD_SAFETY_OBJECT renderer_mutex;
-    OE_RendererBase*        renderer{nullptr};
+    oe::renderer_base_t*    renderer{nullptr};
 
     OE_THREAD_SAFETY_OBJECT physics_mutex;
-    OE_PhysicsEngineBase*   physics{nullptr};
+    oe::physics_base_t*     physics{nullptr};
 
     OE_THREAD_SAFETY_OBJECT window_mutex;
-    OE_WindowSystemBase*    window{nullptr};
+    oe::winsys_base_t*      window{nullptr};
 
-    OE_NetworkingBase* network{nullptr};
+    oe::networking_base_t* network{nullptr};
 
     std::shared_ptr<OE_World> world{nullptr};
 

--- a/include/OE/task_manager.h
+++ b/include/OE/task_manager.h
@@ -106,7 +106,7 @@ public:
 
     // very important variable
     std::atomic<bool> done;
-
+    bool              errors_on_init{false};
 
     OE_THREAD_SAFETY_OBJECT  renderer_mutex;
     oe::renderer_base_t*     renderer{nullptr};
@@ -196,15 +196,16 @@ private:
     int tryRun_unsync_thread(OE_UnsyncThreadData*);
     int tryRun_task(const std::string&, OE_Task&);
 
-    void tryRun_physics_updateMultiThread(const std::string&, const int&);
+    // ALL these return true if error is found so it terminates the engine
+    bool tryRun_physics_updateMultiThread(const std::string&, const int&);
     bool tryRun_renderer_updateSingleThread();
-    void tryRun_renderer_updateData();
+    bool tryRun_renderer_updateData();
     bool tryRun_winsys_update();
 
-    void tryRun_winsys_init(int, int, std::string, bool, oe::winsys_init_info);
-    void tryRun_physics_init(oe::physics_init_info);
-    void tryRun_renderer_init(oe::renderer_init_info);
-    void tryRun_network_init(oe::networking_init_info);
+    bool tryRun_winsys_init(int, int, std::string, bool, oe::winsys_init_info);
+    bool tryRun_physics_init(oe::physics_init_info);
+    bool tryRun_renderer_init(oe::renderer_init_info);
+    bool tryRun_network_init(oe::networking_init_info);
 };
 
 #endif

--- a/include/OE/task_manager.h
+++ b/include/OE/task_manager.h
@@ -112,11 +112,13 @@ public:
     oe::renderer_base_t*     renderer{nullptr};
     oe::renderer_init_info   renderer_init_info;
     oe::renderer_update_info renderer_info;
+    bool                     renderer_init_errors{false};
     std::atomic<bool>        restart_renderer{false};
 
     OE_THREAD_SAFETY_OBJECT physics_mutex;
     oe::physics_base_t*     physics{nullptr};
     oe::physics_update_info physics_info;
+    bool                    physics_init_errors{false};
     oe::physics_init_info   physics_init_info;
 
     OE_THREAD_SAFETY_OBJECT window_mutex;
@@ -124,9 +126,11 @@ public:
     oe::winsys_update_info  window_info;
     oe::winsys_init_info    window_init_info;
     oe::winsys_output       window_output;
+    bool                    winsys_init_errors{false};
 
     oe::networking_base_t*   network{nullptr};
     oe::networking_init_info network_init_info;
+    bool                     network_init_errors{false};
 
     std::shared_ptr<OE_World> world{nullptr};
 

--- a/include/OE/task_manager.h
+++ b/include/OE/task_manager.h
@@ -108,16 +108,25 @@ public:
     std::atomic<bool> done;
 
 
-    OE_THREAD_SAFETY_OBJECT renderer_mutex;
-    oe::renderer_base_t*    renderer{nullptr};
+    OE_THREAD_SAFETY_OBJECT  renderer_mutex;
+    oe::renderer_base_t*     renderer{nullptr};
+    oe::renderer_init_info   renderer_init_info;
+    oe::renderer_update_info renderer_info;
+    std::atomic<bool>        restart_renderer{false};
 
     OE_THREAD_SAFETY_OBJECT physics_mutex;
     oe::physics_base_t*     physics{nullptr};
+    oe::physics_update_info physics_info;
+    oe::physics_init_info   physics_init_info;
 
     OE_THREAD_SAFETY_OBJECT window_mutex;
     oe::winsys_base_t*      window{nullptr};
+    oe::winsys_update_info  window_info;
+    oe::winsys_init_info    window_init_info;
+    oe::winsys_output       window_output;
 
-    oe::networking_base_t* network{nullptr};
+    oe::networking_base_t*   network{nullptr};
+    oe::networking_init_info network_init_info;
 
     std::shared_ptr<OE_World> world{nullptr};
 
@@ -145,7 +154,8 @@ public:
 
 
     // Main functions
-    int  Init(std::string, int, int, bool, bool);
+    int  Init(std::string, int, int, bool, oe::renderer_init_info, oe::winsys_init_info, oe::physics_init_info,
+              oe::networking_init_info);
     void CreateNewThread(std::string);
     void CreateUnsyncThread(std::string, const OE_METHOD);
     void Step();
@@ -191,10 +201,10 @@ private:
     void tryRun_renderer_updateData();
     bool tryRun_winsys_update();
 
-    void tryRun_winsys_init(int, int, std::string, bool, bool, void*);
-    void tryRun_physics_init();
-    void tryRun_renderer_init();
-    void tryRun_network_init();
+    void tryRun_winsys_init(int, int, std::string, bool, oe::winsys_init_info);
+    void tryRun_physics_init(oe::physics_init_info);
+    void tryRun_renderer_init(oe::renderer_init_info);
+    void tryRun_network_init(oe::networking_init_info);
 };
 
 #endif

--- a/include/OE/types/polygon_storage.h
+++ b/include/OE/types/polygon_storage.h
@@ -108,13 +108,17 @@ public:
  * A LOT of stuff will be broken if you do sth wrong
  */
 
+namespace nre {
+    class data_handler_t;
+}
+
 class OE_PolygonStorage32 {
 
     //	friend class CSL_Interpreter;
     friend class OE_Mesh32;
     friend class NRE_Renderer;
     friend class NRE_RendererLegacy;
-    friend class NRE_DataHandler;
+    friend class nre::data_handler_t;
 
 public:
     OE_PolygonStorage32(uint32_t num_of_vertices, uint32_t num_of_normals, uint32_t num_of_triangles, uint32_t num_of_uvs,

--- a/include/OE/types/shared_index_map.h
+++ b/include/OE/types/shared_index_map.h
@@ -233,6 +233,7 @@ public:
         this->elements_[element->id] = element;
         this->id2name_[element->id]  = name;
         this->changed_.add(element->id);
+        this->names_.insert(name);
     }
 
     std::string to_str() {
@@ -318,8 +319,10 @@ public:
         auto output = Element();
 
         lockMutex();
-        if (elements_.count(name2id[name]) != 0)
-            output = Element(this, name2id[name], elements_[name2id[name]]);
+        if (this->names_.count(name) != 0) {
+            size_t elem_id = name2id[name];
+            output         = Element(this, elem_id, elements_[elem_id]);
+        }
         else
             output = Element(this, name2id[name], nullptr);
         unlockMutex();

--- a/include/OE/winsys_sdl2.h
+++ b/include/OE/winsys_sdl2.h
@@ -9,16 +9,16 @@ public:
     OE_SDL_WindowSystem();
     ~OE_SDL_WindowSystem();
 
-    bool init(int, int, std::string, bool, bool, void*);
-    bool update();
+    oe::winsys_output init(oe::winsys_init_info, oe::winsys_update_info);
+    oe::winsys_output update(oe::winsys_update_info);
 
-    void finishInit();
 
-    bool getMouseLockedState();
-    void lockMouse();
-    void unlockMouse();
 
-    bool updateEvents();
+    bool is_mouse_locked();
+    void lock_mouse();
+    void unlock_mouse();
+
+    bool update_events();
     void destroy();
 
     SDL_Window*   window{nullptr};
@@ -31,8 +31,24 @@ public:
     bool mouse_moved{false};
 
 protected:
-    void updateWindowEvents();
-    void createWindow(int, int);
+    void              updateWindowEvents();
+    void              createWindow(int, int);
+    oe::winsys_output finishInit();
+
+    int  resolution_x{0};
+    int  resolution_y{0};
+    int  dpi{96};
+    bool vsync{true};
+
+    // For different OpenGL versions
+    std::string title;
+    bool        fullscreen{false};
+    int         major{0};
+    int         minor{0};
+    bool        isES{false};
+    bool        mouse_locked{false};
+
+    std::atomic<bool> restart_renderer{false};
 };
 
 

--- a/include/OE/winsys_sdl2.h
+++ b/include/OE/winsys_sdl2.h
@@ -4,7 +4,7 @@
 #include <OE/dummy_classes.h>
 #include <OE/types/libs_oe.h>
 
-class OE_SDL_WindowSystem : public OE_WindowSystemBase {
+class OE_SDL_WindowSystem : public oe::winsys_base_t {
 public:
     OE_SDL_WindowSystem();
     ~OE_SDL_WindowSystem();

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('Oxygen Engine', ['cpp', 'c'], default_options : ['cpp_std=c++17', 'buildtype=debugoptimized'])
+project('Oxygen Engine', ['cpp', 'c'], default_options : ['cpp_std=c++20', 'buildtype=debugoptimized'])
 
 src = ['src/Renderer/glad.c',
        'src/Renderer/api_gpu.cpp',

--- a/src/Events/event.cpp
+++ b/src/Events/event.cpp
@@ -4,108 +4,82 @@
 
 using namespace std;
 
-bool OE_Event::finished = false;
+//bool oe::event_t::finished = false;
 
-OE_Event::OE_Event() {
+oe::event_t::event_t() {
     active_ = false;
     name_   = "";
 }
 
-OE_Event::~OE_Event() {
+oe::event_t::~event_t() {
 }
 
-void OE_Event::setFunc(const OE_EVENTFUNC a_func) {
+void oe::event_t::set_func(const oe::event_func_type a_func) {
     lockMutex();
     func_ = a_func;
     unlockMutex();
 }
 
 // keyboard
-OE_KeyboardEvent::OE_KeyboardEvent() {
-    type_    = OE_KEYBOARD_EVENT;
-    keystate = OE_BUTTON::RELEASE;
+oe::keyboard_event_t::keyboard_event_t() {
+    type_    = oe::KEYBOARD_EVENT;
+    keystate_ = oe::BUTTON_RELEASE;
 }
-OE_KeyboardEvent::~OE_KeyboardEvent() {
+oe::keyboard_event_t::~keyboard_event_t() {
 }
 
-int OE_KeyboardEvent::call() {
+int oe::keyboard_event_t::call() {
 
     return internal_call();
 }
 
 // mouse
-int  OE_MouseEvent::x           = 0;
-int  OE_MouseEvent::y           = 0;
-int  OE_MouseEvent::delta_x     = 0;
-int  OE_MouseEvent::delta_y     = 0;
-int  OE_MouseEvent::mouse_wheel = 0;
-bool OE_MouseEvent::mousemoved  = false;
-
-OE_MouseEvent::OE_MouseEvent() {
-    type_      = OE_MOUSE_EVENT;
-    mousemoved = false;
-    keystate   = OE_BUTTON::RELEASE;
+oe::mouse_event_t::mouse_event_t() {
+    type_      = oe::MOUSE_EVENT;
+    keystate_  = oe::BUTTON_RELEASE;
 }
-OE_MouseEvent::~OE_MouseEvent() {
+oe::mouse_event_t::~mouse_event_t() {
 }
 
-int OE_MouseEvent::call() {
+int oe::mouse_event_t::call() {
+
+    return internal_call();
+}
+
+// mouse move
+oe::mouse_move_event_t::mouse_move_event_t() {
+    type_      = oe::MOUSE_MOVE_EVENT;
+}
+oe::mouse_move_event_t::~mouse_move_event_t() {
+}
+
+int oe::mouse_move_event_t::call() {
 
     return internal_call();
 }
 
 // gamepad
-OE_GamepadEvent::OE_GamepadEvent() {
-    type_     = OE_GAMEPAD_EVENT;
-    axis      = 0;
-    axismoved = false;
+oe::gamepad_event_t::gamepad_event_t() {
+    type_     = oe::GAMEPAD_EVENT;
+    axis_      = 0;
+    axismoved_ = false;
 }
-OE_GamepadEvent::~OE_GamepadEvent() {
+oe::gamepad_event_t::~gamepad_event_t() {
 }
 
-int OE_GamepadEvent::call() {
+int oe::gamepad_event_t::call() {
 
     return internal_call();
 }
 
 // custom
-OE_CustomEvent::OE_CustomEvent() {
-    type_ = OE_CUSTOM_EVENT;
+oe::custom_event_t::custom_event_t() {
+    type_ = oe::CUSTOM_EVENT;
 }
-OE_CustomEvent::~OE_CustomEvent() {
-}
-
-int OE_CustomEvent::call() {
-
-    return internal_call();
+oe::custom_event_t::~custom_event_t() {
 }
 
-// error
-OE_ErrorEvent::OE_ErrorEvent() {
-    type_ = OE_ERROR_EVENT;
-}
-OE_ErrorEvent::~OE_ErrorEvent() {
-}
-
-int OE_ErrorEvent::call() {
-
-    /***************************/
-    /// non-generic handling
-    if (this->importance == OE_FATAL) finished = true;
-
-    this->internal_call();
-
-    return 0;
-}
-
-// multiple events
-OE_EventCombo::OE_EventCombo() {
-    type_ = OE_EVENT_COMBO;
-}
-OE_EventCombo::~OE_EventCombo() {
-}
-
-int OE_EventCombo::call() {
+int oe::custom_event_t::call() {
 
     return internal_call();
 }

--- a/src/Events/event.cpp
+++ b/src/Events/event.cpp
@@ -5,10 +5,12 @@
 using namespace std;
 
 // bool oe::event_t::finished = false;
+std::atomic<size_t> oe::event_t::current_id(0);
 
 oe::event_t::event_t() {
-    active_ = false;
-    name_   = "";
+    active_  = false;
+    name_    = "";
+    this->id = ++oe::event_t::current_id;
 }
 
 oe::event_t::~event_t() {

--- a/src/Events/event.cpp
+++ b/src/Events/event.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-//bool oe::event_t::finished = false;
+// bool oe::event_t::finished = false;
 
 oe::event_t::event_t() {
     active_ = false;
@@ -22,7 +22,7 @@ void oe::event_t::set_func(const oe::event_func_type a_func) {
 
 // keyboard
 oe::keyboard_event_t::keyboard_event_t() {
-    type_    = oe::KEYBOARD_EVENT;
+    type_     = oe::KEYBOARD_EVENT;
     keystate_ = oe::BUTTON_RELEASE;
 }
 oe::keyboard_event_t::~keyboard_event_t() {
@@ -35,8 +35,8 @@ int oe::keyboard_event_t::call() {
 
 // mouse
 oe::mouse_event_t::mouse_event_t() {
-    type_      = oe::MOUSE_EVENT;
-    keystate_  = oe::BUTTON_RELEASE;
+    type_     = oe::MOUSE_EVENT;
+    keystate_ = oe::BUTTON_RELEASE;
 }
 oe::mouse_event_t::~mouse_event_t() {
 }
@@ -48,7 +48,7 @@ int oe::mouse_event_t::call() {
 
 // mouse move
 oe::mouse_move_event_t::mouse_move_event_t() {
-    type_      = oe::MOUSE_MOVE_EVENT;
+    type_ = oe::MOUSE_MOVE_EVENT;
 }
 oe::mouse_move_event_t::~mouse_move_event_t() {
 }
@@ -60,7 +60,7 @@ int oe::mouse_move_event_t::call() {
 
 // gamepad
 oe::gamepad_event_t::gamepad_event_t() {
-    type_     = oe::GAMEPAD_EVENT;
+    type_      = oe::GAMEPAD_EVENT;
     axis_      = 0;
     axismoved_ = false;
 }

--- a/src/Events/event_handler.cpp
+++ b/src/Events/event_handler.cpp
@@ -4,20 +4,20 @@
 using namespace std;
 
 int oe::template_event_func(OE_Task task, string event_name) {
-    cout << event_name << endl;
+    // cout << event_name << endl;
     return 0;
 }
 
 oe::event_handler_t::event_handler_t() {
-    done = false;
+    done_ = false;
 }
 void oe::event_handler_t::init() {
-    auto internal_events = this->input_handler.createEvents();
+    auto internal_events = this->input_handler_.create_events();
     for (auto x : internal_events) {
         this->events_list_.append(x.first, x.second);
         this->happened_events_counter_[events_list_[x.first].id_] = 0;
     }
-    this->done = false;
+    this->done_ = false;
 }
 
 oe::event_handler_t::~event_handler_t() {
@@ -25,7 +25,7 @@ oe::event_handler_t::~event_handler_t() {
 }
 
 // THIS IS VERY USEFUL
-std::shared_ptr<oe::event_t> oe::event_handler_t::getIEvent(const string& event_name) {
+std::shared_ptr<oe::event_t> oe::event_handler_t::get_ievent(const string& event_name) {
     /// Updated this function to 2022
     lockMutex();
 
@@ -51,7 +51,7 @@ std::size_t oe::event_handler_t::get_event_id(const string& event_name) {
 }
 
 
-void oe::event_handler_t::createUserEvent(const string& event_name) {
+void oe::event_handler_t::create_user_event(const string& event_name) {
 
     std::shared_ptr<oe::custom_event_t> event = std::make_shared<oe::custom_event_t>();
     event->name_                              = event_name;
@@ -67,11 +67,11 @@ void oe::event_handler_t::createUserEvent(const string& event_name) {
 
 
 
-void oe::event_handler_t::destroyIEvent(size_t a_name) {
+void oe::event_handler_t::destroy_ievent(size_t event_id) {
     lockMutex();
 
-    if (this->events_list_.count(a_name) != 0) {
-        events_list_.remove(events_list_[a_name].id_);
+    if (this->events_list_.count(event_id) != 0) {
+        events_list_.remove(events_list_[event_id].id_);
     }
     else {
         // TODO: Warning
@@ -80,9 +80,9 @@ void oe::event_handler_t::destroyIEvent(size_t a_name) {
     unlockMutex();
     // return output;
 }
-void oe::event_handler_t::setIEventFunc(size_t a_name, const oe::event_func_type func) {
+void oe::event_handler_t::set_ievent_func(size_t event_id, const oe::event_func_type func) {
     lockMutex();
-    auto event = events_list_[a_name];
+    auto event = events_list_[event_id];
     if (event.is_valid()) {
         event.p_->set_func(func);
     }
@@ -92,7 +92,7 @@ void oe::event_handler_t::setIEventFunc(size_t a_name, const oe::event_func_type
 
     unlockMutex();
 }
-void oe::event_handler_t::setIEventFunc(const string& event_name, const oe::event_func_type func) {
+void oe::event_handler_t::set_ievent_func(const string& event_name, const oe::event_func_type func) {
     lockMutex();
     auto event = events_list_[event_name];
     if (event.is_valid()) {
@@ -106,7 +106,7 @@ void oe::event_handler_t::setIEventFunc(const string& event_name, const oe::even
     unlockMutex();
 }
 
-void oe::event_handler_t::mapIEvent(size_t upper, size_t target) {
+void oe::event_handler_t::map_ievent(size_t upper, size_t target) {
     lockMutex();
     if (this->events_list_.count(target) != 0) {
         this->events_list_[target].p_->sub_events_.insert(upper);
@@ -118,7 +118,7 @@ void oe::event_handler_t::mapIEvent(size_t upper, size_t target) {
     unlockMutex();
 }
 
-void oe::event_handler_t::unmapIEvent(size_t upper, size_t target) {
+void oe::event_handler_t::unmap_ievent(size_t upper, size_t target) {
     lockMutex();
     auto event = events_list_[target];
     if (event.is_valid()) {
@@ -131,12 +131,12 @@ void oe::event_handler_t::unmapIEvent(size_t upper, size_t target) {
     unlockMutex();
 }
 /// so simple
-void oe::event_handler_t::broadcastIEvent(size_t a_name) {
+void oe::event_handler_t::broadcast_ievent(size_t event_id) {
 
     unordered_set<size_t> tobecalled_events;
     lockMutex();
 
-    auto event = events_list_[a_name];
+    auto event = events_list_[event_id];
     if (event.is_valid()) {
         event.flag_as_registered();
         tobecalled_events = event.p_->sub_events_;
@@ -149,10 +149,10 @@ void oe::event_handler_t::broadcastIEvent(size_t a_name) {
 
     /// broadcast any sub events (which in turn broadcast their sub events etc.)
     for (auto& x : tobecalled_events)
-        this->broadcastIEvent(x);
+        this->broadcast_ievent(x);
 }
 
-void oe::event_handler_t::broadcastIEvent(const string& event_name) {
+void oe::event_handler_t::broadcast_ievent(const string& event_name) {
 
     unordered_set<size_t> tobecalled_events;
     lockMutex();
@@ -171,18 +171,18 @@ void oe::event_handler_t::broadcastIEvent(const string& event_name) {
 
     /// broadcast any sub events (which in turn broadcast their sub events etc.)
     for (auto& x : tobecalled_events)
-        this->broadcastIEvent(x);
+        this->broadcast_ievent(x);
 }
 
 // TODO
-void oe::event_handler_t::broadcastIEventWait(size_t a_name, int milliseconds) {
+void oe::event_handler_t::broadcast_ievent_wait(size_t event_id, int milliseconds) {
 }
 
 /// so simple
-int oe::event_handler_t::callIEvent(size_t a_name) {
+int oe::event_handler_t::call_ievent(size_t event_id) {
 
     /// generic event management
-    auto event = events_list_[a_name];
+    auto event = events_list_[event_id];
     if (event.is_valid()) {
 
         event.p_->lockMutex();
@@ -196,11 +196,11 @@ int oe::event_handler_t::callIEvent(size_t a_name) {
     return 0;
 }
 
-std::size_t oe::event_handler_t::getEventActivations(std::size_t a_name) {
+std::size_t oe::event_handler_t::get_event_activations(std::size_t event_id) {
     size_t output = 0;
     lockMutex();
-    if (this->events_list_.count(a_name) == 1) {
-        output = this->happened_events_counter_[a_name];
+    if (this->events_list_.count(event_id) == 1) {
+        output = this->happened_events_counter_[event_id];
     }
     else {
         // TODO: Warning
@@ -209,9 +209,9 @@ std::size_t oe::event_handler_t::getEventActivations(std::size_t a_name) {
     return output;
 }
 
-std::size_t oe::event_handler_t::getEventCounter(std::size_t a_name) {
+std::size_t oe::event_handler_t::get_event_counter(std::size_t event_id) {
     size_t output = 0;
-    auto   event  = events_list_[a_name];
+    auto   event  = events_list_[event_id];
     if (event.is_valid()) {
         event.p_->lockMutex();
         output = event.p_->task_.GetCounter();
@@ -221,7 +221,7 @@ std::size_t oe::event_handler_t::getEventCounter(std::size_t a_name) {
 }
 
 
-bool oe::event_handler_t::havePendingEvents() {
+bool oe::event_handler_t::has_pending_events() {
     lockMutex();
     bool output = this->events_list_.has_registered_events();
     unlockMutex();
@@ -231,7 +231,7 @@ bool oe::event_handler_t::havePendingEvents() {
 /*IMPORTANT
  * this function is run in the main thread only in the 2020 version
  */
-int oe::event_handler_t::handleAllEvents() {
+int oe::event_handler_t::handle_all_events() {
 
     lockMutex();
     for (auto x : this->happened_events_counter_) {
@@ -239,7 +239,7 @@ int oe::event_handler_t::handleAllEvents() {
     }
     unlockMutex();
 
-    while (havePendingEvents()) {
+    while (this->has_pending_events()) {
 
         /// fetch an event and delete it from the queue
         ///  so that other threads target next events
@@ -255,7 +255,7 @@ int oe::event_handler_t::handleAllEvents() {
         unlockMutex();
 
         for (auto a_event : happened_events_)
-            callIEvent(a_event);
+            call_ievent(a_event);
     }
 
     this->cleanup();

--- a/src/Events/event_handler.cpp
+++ b/src/Events/event_handler.cpp
@@ -3,14 +3,14 @@
 
 using namespace std;
 
-int template_event_func(OE_Task task, string event_name) { /*cout << event_name << endl;*/
+int oe::template_event_func(OE_Task task, string event_name) { /*cout << event_name << endl;*/
     return 0;
 }
 
-OE_EventHandler::OE_EventHandler() {
+oe::event_handler_t::event_handler_t() {
     done = false;
 }
-void OE_EventHandler::init() {
+void oe::event_handler_t::init() {
     this->input_handler.createEvents(&this->internal_events);
     for (auto x : this->internal_events) {
         this->happened_events_counter[x.first] = 0;
@@ -18,17 +18,17 @@ void OE_EventHandler::init() {
     this->done = false;
 }
 
-OE_EventHandler::~OE_EventHandler() {
+oe::event_handler_t::~event_handler_t() {
     this->internal_events.clear();
     this->happened_events_counter.clear();
 }
 
 // THIS IS VERY USEFUL
-std::shared_ptr<OE_Event> OE_EventHandler::getIEvent(string a_name) {
+std::shared_ptr<oe::event_t> oe::event_handler_t::getIEvent(string a_name) {
     /// wraps getIEventUNSAFE in a mutex, (now in 2020: like... seriously????)
     lockMutex();
 
-    std::shared_ptr<OE_Event> output = getIEventUNSAFE(a_name);
+    std::shared_ptr<oe::event_t> output = getIEventUNSAFE(a_name);
 
     if (output == nullptr) {
         unlockMutex();
@@ -39,7 +39,7 @@ std::shared_ptr<OE_Event> OE_EventHandler::getIEvent(string a_name) {
     return output;
 }
 
-std::shared_ptr<OE_Event> OE_EventHandler::getIEventUNSAFE(string a_name) {
+std::shared_ptr<oe::event_t> oe::event_handler_t::getIEventUNSAFE(string a_name) {
     /// function to simplify fetching an event by name
     /// WARNING: DO NOT USE THE FUNCTION OUTSIDE OF MUTEXES
 
@@ -48,11 +48,11 @@ std::shared_ptr<OE_Event> OE_EventHandler::getIEventUNSAFE(string a_name) {
     return nullptr;
 }
 
-void OE_EventHandler::createUserEvent(string a_name) {
+void oe::event_handler_t::createUserEvent(string a_name) {
 
-    std::shared_ptr<OE_CustomEvent> event = std::make_shared<OE_CustomEvent>();
+    std::shared_ptr<oe::custom_event_t> event = std::make_shared<oe::custom_event_t>();
     event->name_                          = a_name;
-    event->setFunc(&template_event_func);
+    event->set_func(&template_event_func);
 
     lockMutex();
     if (internal_events.count(a_name) == 0) {
@@ -64,7 +64,7 @@ void OE_EventHandler::createUserEvent(string a_name) {
 
 
 
-void OE_EventHandler::destroyIEvent(string a_name) {
+void oe::event_handler_t::destroyIEvent(string a_name) {
     lockMutex();
 
     this->obsolete_events.push_back(a_name);
@@ -72,10 +72,10 @@ void OE_EventHandler::destroyIEvent(string a_name) {
     unlockMutex();
     // return output;
 }
-void OE_EventHandler::setIEventFunc(string a_name, const OE_EVENTFUNC func) {
+void oe::event_handler_t::setIEventFunc(string a_name, const oe::event_func_type func) {
     lockMutex();
     if (getIEventUNSAFE(a_name) != nullptr) {
-        getIEventUNSAFE(a_name)->setFunc(func);
+        getIEventUNSAFE(a_name)->set_func(func);
     }
     else {
         unlockMutex();
@@ -85,7 +85,7 @@ void OE_EventHandler::setIEventFunc(string a_name, const OE_EVENTFUNC func) {
     unlockMutex();
 }
 
-void OE_EventHandler::mapIEvent(string upper, string target) {
+void oe::event_handler_t::mapIEvent(string upper, string target) {
     lockMutex();
     if (getIEventUNSAFE(target) != nullptr) {
         getIEventUNSAFE(target)->sub_events_.insert(upper);
@@ -98,7 +98,7 @@ void OE_EventHandler::mapIEvent(string upper, string target) {
     unlockMutex();
 }
 
-void OE_EventHandler::unmapIEvent(string upper, string target) {
+void oe::event_handler_t::unmapIEvent(string upper, string target) {
     lockMutex();
     if (getIEventUNSAFE(target) != nullptr) {
         getIEventUNSAFE(target)->sub_events_.erase(getIEventUNSAFE(target)->sub_events_.find(upper));
@@ -111,7 +111,7 @@ void OE_EventHandler::unmapIEvent(string upper, string target) {
     unlockMutex();
 }
 /// so simple
-void OE_EventHandler::broadcastIEvent(string a_name) {
+void oe::event_handler_t::broadcastIEvent(string a_name) {
 
     set<string> tobecalled_events;
     lockMutex();
@@ -133,11 +133,11 @@ void OE_EventHandler::broadcastIEvent(string a_name) {
 }
 
 // TODO
-void OE_EventHandler::broadcastIEventWait(string a_name, int milliseconds) {
+void oe::event_handler_t::broadcastIEventWait(string a_name, int milliseconds) {
 }
 
 /// so simple
-int OE_EventHandler::callIEvent(string a_name) {
+int oe::event_handler_t::callIEvent(string a_name) {
 
     /// generic event management
     auto event = getIEvent(a_name);
@@ -155,7 +155,7 @@ int OE_EventHandler::callIEvent(string a_name) {
     return 0;
 }
 
-std::size_t OE_EventHandler::getEventActivations(std::string a_name) {
+std::size_t oe::event_handler_t::getEventActivations(std::string a_name) {
     size_t output = 0;
     lockMutex();
     if (this->happened_events_counter.count(a_name) == 1) {
@@ -169,7 +169,7 @@ std::size_t OE_EventHandler::getEventActivations(std::string a_name) {
     return output;
 }
 
-std::size_t OE_EventHandler::getEventCounter(std::string a_name) {
+std::size_t oe::event_handler_t::getEventCounter(std::string a_name) {
     size_t output = 0;
     auto   event  = getIEvent(a_name);
     if (event != nullptr) {
@@ -181,7 +181,7 @@ std::size_t OE_EventHandler::getEventCounter(std::string a_name) {
 }
 
 
-bool OE_EventHandler::havePendingEvents() {
+bool oe::event_handler_t::havePendingEvents() {
     lockMutex();
     bool output = !this->pending_events.empty();
     unlockMutex();
@@ -191,7 +191,7 @@ bool OE_EventHandler::havePendingEvents() {
 /*IMPORTANT
  * this function is run in the main thread only in the 2020 version
  */
-int OE_EventHandler::handleAllEvents() {
+int oe::event_handler_t::handleAllEvents() {
 
     lockMutex();
     for (auto x : this->happened_events_counter) {
@@ -225,7 +225,7 @@ int OE_EventHandler::handleAllEvents() {
     return 0;
 }
 
-void OE_EventHandler::cleanup() {
+void oe::event_handler_t::cleanup() {
 
     lockMutex();
 
@@ -238,4 +238,20 @@ void OE_EventHandler::cleanup() {
     obsolete_events.clear();
 
     unlockMutex();
+}
+
+int oe::event_handler_t::get_mouse_x(){
+    return mouse_x_;
+}
+int oe::event_handler_t::get_mouse_y(){
+    return mouse_y_;
+}
+int oe::event_handler_t::get_mouse_delta_y(){
+    return mouse_delta_y_;
+}
+int oe::event_handler_t::get_mouse_delta_x(){
+    return mouse_delta_x_;
+}
+bool oe::event_handler_t::has_mouse_moved(){
+    return mouse_moved_;
 }

--- a/src/Events/event_handler.cpp
+++ b/src/Events/event_handler.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<oe::event_t> oe::event_handler_t::getIEventUNSAFE(string a_name)
 void oe::event_handler_t::createUserEvent(string a_name) {
 
     std::shared_ptr<oe::custom_event_t> event = std::make_shared<oe::custom_event_t>();
-    event->name_                          = a_name;
+    event->name_                              = a_name;
     event->set_func(&template_event_func);
 
     lockMutex();
@@ -240,18 +240,18 @@ void oe::event_handler_t::cleanup() {
     unlockMutex();
 }
 
-int oe::event_handler_t::get_mouse_x(){
+int oe::event_handler_t::get_mouse_x() {
     return mouse_x_;
 }
-int oe::event_handler_t::get_mouse_y(){
+int oe::event_handler_t::get_mouse_y() {
     return mouse_y_;
 }
-int oe::event_handler_t::get_mouse_delta_y(){
+int oe::event_handler_t::get_mouse_delta_y() {
     return mouse_delta_y_;
 }
-int oe::event_handler_t::get_mouse_delta_x(){
+int oe::event_handler_t::get_mouse_delta_x() {
     return mouse_delta_x_;
 }
-bool oe::event_handler_t::has_mouse_moved(){
+bool oe::event_handler_t::has_mouse_moved() {
     return mouse_moved_;
 }

--- a/src/Events/event_handler.cpp
+++ b/src/Events/event_handler.cpp
@@ -11,7 +11,7 @@ oe::event_handler_t::event_handler_t() {
     done = false;
 }
 void oe::event_handler_t::init() {
-    this->input_handler.createEvents(&this->internal_events);
+    this->internal_events = this->input_handler.createEvents();
     for (auto x : this->internal_events) {
         this->happened_events_counter[x.first] = 0;
     }

--- a/src/Events/event_parser.cpp
+++ b/src/Events/event_parser.cpp
@@ -1,7 +1,1 @@
 #include <OE/Events/event.h> //IMPORTANT
-
-OE_EventPair::OE_EventPair() {
-}
-
-OE_EventPair::~OE_EventPair() {
-}

--- a/src/Events/input_event_handler.cpp
+++ b/src/Events/input_event_handler.cpp
@@ -181,7 +181,7 @@ void oe::event_handler_t::internal_register_keyup_event(const std::string& name)
         oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(get_ievent(name + "-").get());
         oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(get_ievent(name + "").get());
 
-        if (just_pressed->keystate_ < oe::BUTTON_JUST_RELEASE) {
+        while (just_pressed->keystate_ < oe::BUTTON_JUST_RELEASE) {
             just_pressed->keystate_ += 1;
             just_released->keystate_ += 1;
             held->keystate_ += 1;

--- a/src/Events/input_event_handler.cpp
+++ b/src/Events/input_event_handler.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-OE_InputEventHandler::OE_InputEventHandler() {
+oe::input_event_handler_t::input_event_handler_t() {
     mouseList = {
         {SDL_BUTTON_LEFT, "1"}, {SDL_BUTTON_RIGHT, "2"}, {SDL_BUTTON_MIDDLE, "3"}, {SDL_BUTTON_X1, "4"}, {SDL_BUTTON_X2, "5"}};
     keyList = {
@@ -22,96 +22,94 @@ OE_InputEventHandler::OE_InputEventHandler() {
         {SDLK_SEMICOLON, ";"}, {SDLK_PERIOD, "."},      {SDLK_COMMA, ","},       {SDLK_DELETE, "del"},  {SDLK_EQUALS, "="},
         {SDLK_SLASH, "/"},     {SDLK_TAB, "tab"},       {SDLK_MINUS, "-"},       {SDLK_BACKSLASH, "\\"}};
 }
-OE_InputEventHandler::~OE_InputEventHandler() {
+oe::input_event_handler_t::~input_event_handler_t() {
 }
 
-void OE_InputEventHandler::createEvents(std::map<std::string, std::shared_ptr<OE_Event>>* event_list) {
+void oe::input_event_handler_t::createEvents(std::map<std::string, std::shared_ptr<oe::event_t>>* event_list) {
 
     /// generate keyboard events
     for (auto x : this->keyList) {
 
         // event for just pressed (sent once per tap)
-        shared_ptr<OE_KeyboardEvent> event = std::make_shared<OE_KeyboardEvent>();
+        shared_ptr<oe::keyboard_event_t> event = std::make_shared<oe::keyboard_event_t>();
         event->name_                       = "keyboard-" + x.second + "+";
-        event->key                         = x.second;
-        event->setFunc(&template_event_func);
+        event->key_                        = x.second;
+        event->set_func(&template_event_func);
         event_list[0][event->name_] = event;
 
         // event for just release (sent once per release)
-        shared_ptr<OE_KeyboardEvent> event1 = std::make_shared<OE_KeyboardEvent>();
+        shared_ptr<oe::keyboard_event_t> event1 = std::make_shared<oe::keyboard_event_t>();
         event1->name_                       = "keyboard-" + x.second + "-";
-        event1->key                         = x.second;
-        event1->setFunc(&template_event_func);
+        event1->key_                        = x.second;
+        event1->set_func(&template_event_func);
         event_list[0][event1->name_] = event1;
 
         // event for hold (sent every frame the key is being held)
-        shared_ptr<OE_KeyboardEvent> event2 = std::make_shared<OE_KeyboardEvent>();
+        shared_ptr<oe::keyboard_event_t> event2 = std::make_shared<oe::keyboard_event_t>();
         event2->name_                       = "keyboard-" + x.second + "";
-        event2->key                         = x.second;
-        event2->setFunc(&template_event_func);
+        event2->key_                        = x.second;
+        event2->set_func(&template_event_func);
         event_list[0][event2->name_] = event2;
     }
 
     /// generate mouse events
     for (auto x : this->mouseList) {
         // event for just pressed (sent once per tap)
-        shared_ptr<OE_MouseEvent> event = std::make_shared<OE_MouseEvent>();
+        shared_ptr<oe::mouse_event_t> event = std::make_shared<oe::mouse_event_t>();
         event->name_                    = "mouse-" + x.second + "+";
-        event->key                      = x.second;
-        event->setFunc(&template_event_func);
+        event->key_                     = x.second;
+        event->set_func(&template_event_func);
         event_list[0][event->name_] = event;
 
         // event for just release (sent once per release)
-        shared_ptr<OE_MouseEvent> event1 = std::make_shared<OE_MouseEvent>();
+        shared_ptr<oe::mouse_event_t> event1 = std::make_shared<oe::mouse_event_t>();
         event1->name_                    = "mouse-" + x.second + "-";
-        event1->key                      = x.second;
-        event1->setFunc(&template_event_func);
+        event1->key_                     = x.second;
+        event1->set_func(&template_event_func);
         event_list[0][event1->name_] = event1;
 
         // event for hold (sent every frame the key is being held)
-        shared_ptr<OE_MouseEvent> event2 = std::make_shared<OE_MouseEvent>();
+        shared_ptr<oe::mouse_event_t> event2 = std::make_shared<oe::mouse_event_t>();
         event2->name_                    = "mouse-" + x.second + "";
-        event2->key                      = x.second;
-        event2->setFunc(&template_event_func);
+        event2->key_                     = x.second;
+        event2->set_func(&template_event_func);
         event_list[0][event2->name_] = event2;
     }
     /// generate mouse motion event
-    shared_ptr<OE_MouseEvent> event3 = std::make_shared<OE_MouseEvent>();
+    shared_ptr<oe::mouse_move_event_t> event3 = std::make_shared<oe::mouse_move_event_t>();
     event3->name_                    = "mouse-motion";
-    event3->key                      = "";
-    event3->setFunc(&template_event_func);
+    event3->set_func(&template_event_func);
     event_list[0][event3->name_] = event3;
 
     /// generate mouse wheel event
-    shared_ptr<OE_MouseEvent> event4 = std::make_shared<OE_MouseEvent>();
+    shared_ptr<oe::mouse_move_event_t> event4 = std::make_shared<oe::mouse_move_event_t>();
     event4->name_                    = "mouse-wheel";
-    event4->key                      = "";
-    event4->setFunc(&template_event_func);
+    event4->set_func(&template_event_func);
     event_list[0][event4->name_] = event4;
 }
 
-void OE_EventHandler::updateInput() {
+void oe::event_handler_t::updateInput() {
 
     for (auto key : this->input_handler.keyList) {
 
-        OE_KeyboardEvent* just_pressed  = static_cast<OE_KeyboardEvent*>(getIEvent("keyboard-" + key.second + "+").get());
-        OE_KeyboardEvent* just_released = static_cast<OE_KeyboardEvent*>(getIEvent("keyboard-" + key.second + "-").get());
-        OE_KeyboardEvent* held          = static_cast<OE_KeyboardEvent*>(getIEvent("keyboard-" + key.second + "").get());
+        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "+").get());
+        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "-").get());
+        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "").get());
 
         // if button is already pressed once, make it register continuous events
-        if (just_pressed->keystate == OE_BUTTON::JUST_PRESS) {
-            just_pressed->keystate += 1;
-            just_released->keystate += 1;
-            held->keystate += 1;
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) {
+            just_pressed->keystate_ += 1;
+            just_released->keystate_ += 1;
+            held->keystate_ += 1;
         }
-        else if (just_pressed->keystate == OE_BUTTON::PRESS) {
+        else if (just_pressed->keystate_ == oe::BUTTON_PRESS) {
             this->broadcastIEvent(held->name_);
         }
         // if button has just been released stop emitting events
-        else if (just_pressed->keystate == OE_BUTTON::JUST_RELEASE) {
-            just_pressed->keystate  = OE_BUTTON::RELEASE;
-            just_released->keystate = OE_BUTTON::RELEASE;
-            held->keystate          = OE_BUTTON::RELEASE;
+        else if (just_pressed->keystate_ == oe::BUTTON_JUST_RELEASE) {
+            just_pressed->keystate_  = oe::BUTTON_RELEASE;
+            just_released->keystate_ = oe::BUTTON_RELEASE;
+            held->keystate_          = oe::BUTTON_RELEASE;
         }
         else {
         }
@@ -119,24 +117,24 @@ void OE_EventHandler::updateInput() {
 
     for (auto key : this->input_handler.mouseList) {
 
-        OE_MouseEvent* just_pressed  = static_cast<OE_MouseEvent*>(getIEvent("mouse-" + key.second + "+").get());
-        OE_MouseEvent* just_released = static_cast<OE_MouseEvent*>(getIEvent("mouse-" + key.second + "-").get());
-        OE_MouseEvent* held          = static_cast<OE_MouseEvent*>(getIEvent("mouse-" + key.second + "").get());
+        oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(getIEvent("mouse-" + key.second + "+").get());
+        oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(getIEvent("mouse-" + key.second + "-").get());
+        oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(getIEvent("mouse-" + key.second + "").get());
 
         // if button is already pressed once, make it register continuous events
-        if (just_pressed->keystate == OE_BUTTON::JUST_PRESS) {
-            just_pressed->keystate += 1;
-            just_released->keystate += 1;
-            held->keystate += 1;
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) {
+            just_pressed->keystate_ += 1;
+            just_released->keystate_ += 1;
+            held->keystate_ += 1;
         }
-        else if (just_pressed->keystate == OE_BUTTON::PRESS) {
+        else if (just_pressed->keystate_ == oe::BUTTON_PRESS) {
             this->broadcastIEvent(held->name_);
         }
         // if button has just been released stop emitting events
-        else if (just_pressed->keystate == OE_BUTTON::JUST_RELEASE) {
-            just_pressed->keystate  = OE_BUTTON::RELEASE;
-            just_released->keystate = OE_BUTTON::RELEASE;
-            held->keystate          = OE_BUTTON::RELEASE;
+        else if (just_pressed->keystate_ == oe::BUTTON_JUST_RELEASE) {
+            just_pressed->keystate_  = oe::BUTTON_RELEASE;
+            just_released->keystate_ = oe::BUTTON_RELEASE;
+            held->keystate_          = oe::BUTTON_RELEASE;
         }
         else {
         }
@@ -144,7 +142,7 @@ void OE_EventHandler::updateInput() {
     // this->mouse_moved = false;
 }
 
-void OE_EventHandler::internalBroadcastKeyDownEvent(const std::string& name) {
+void oe::event_handler_t::internalBroadcastKeyDownEvent(const std::string& name) {
 
     if (name.length() <= 8)
         assert(name.substr(0, 6) == "mouse-");
@@ -158,36 +156,36 @@ void OE_EventHandler::internalBroadcastKeyDownEvent(const std::string& name) {
     // update mouse event if it exists
     if (name.substr(0, 6) == "mouse-") {
 
-        OE_MouseEvent* just_pressed  = static_cast<OE_MouseEvent*>(getIEvent(name + "+").get());
-        OE_MouseEvent* just_released = static_cast<OE_MouseEvent*>(getIEvent(name + "-").get());
-        OE_MouseEvent* held          = static_cast<OE_MouseEvent*>(getIEvent(name + "").get());
+        oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(getIEvent(name + "+").get());
+        oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(getIEvent(name + "-").get());
+        oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(getIEvent(name + "").get());
 
-        if (just_pressed->keystate < OE_BUTTON::PRESS) {
-            just_pressed->keystate += 1;
-            just_released->keystate += 1;
-            held->keystate += 1;
+        if (just_pressed->keystate_ < oe::BUTTON_PRESS) {
+            just_pressed->keystate_ += 1;
+            just_released->keystate_ += 1;
+            held->keystate_ += 1;
         }
-        if (just_pressed->keystate == OE_BUTTON::JUST_PRESS) this->broadcastIEvent(just_pressed->name_);
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcastIEvent(just_pressed->name_);
     }
     // update keyboard event if it exists
     else if (name.substr(0, 9) == "keyboard-") {
 
-        OE_KeyboardEvent* just_pressed  = static_cast<OE_KeyboardEvent*>(getIEvent(name + "+").get());
-        OE_KeyboardEvent* just_released = static_cast<OE_KeyboardEvent*>(getIEvent(name + "-").get());
-        OE_KeyboardEvent* held          = static_cast<OE_KeyboardEvent*>(getIEvent(name + "").get());
+        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(getIEvent(name + "+").get());
+        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(getIEvent(name + "-").get());
+        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(getIEvent(name + "").get());
 
-        if (just_pressed->keystate < OE_BUTTON::JUST_PRESS) {
-            just_pressed->keystate += 1;
-            just_released->keystate += 1;
-            held->keystate += 1;
+        if (just_pressed->keystate_ < oe::BUTTON_JUST_PRESS) {
+            just_pressed->keystate_ += 1;
+            just_released->keystate_ += 1;
+            held->keystate_ += 1;
         }
-        if (just_pressed->keystate == OE_BUTTON::JUST_PRESS) this->broadcastIEvent(just_pressed->name_);
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcastIEvent(just_pressed->name_);
     }
     else {
     }
 }
 
-void OE_EventHandler::internalBroadcastKeyUpEvent(const std::string& name) {
+void oe::event_handler_t::internalBroadcastKeyUpEvent(const std::string& name) {
     if (name.length() <= 8)
         assert(name.substr(0, 6) == "mouse-");
     else if (name.length() > 8)
@@ -200,16 +198,16 @@ void OE_EventHandler::internalBroadcastKeyUpEvent(const std::string& name) {
     // update mouse event if it exists
     if (name.substr(0, 6) == "mouse-") {
 
-        OE_MouseEvent* just_pressed  = static_cast<OE_MouseEvent*>(getIEvent(name + "+").get());
-        OE_MouseEvent* just_released = static_cast<OE_MouseEvent*>(getIEvent(name + "-").get());
-        OE_MouseEvent* held          = static_cast<OE_MouseEvent*>(getIEvent(name + "").get());
+        oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(getIEvent(name + "+").get());
+        oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(getIEvent(name + "-").get());
+        oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(getIEvent(name + "").get());
 
-        if (just_pressed->keystate < OE_BUTTON::JUST_RELEASE) {
-            just_pressed->keystate += 1;
-            just_released->keystate += 1;
-            held->keystate += 1;
+        if (just_pressed->keystate_ < oe::BUTTON_JUST_RELEASE) {
+            just_pressed->keystate_ += 1;
+            just_released->keystate_ += 1;
+            held->keystate_ += 1;
         }
-        if (just_pressed->keystate == OE_BUTTON::JUST_RELEASE)
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_RELEASE)
             this->broadcastIEvent(just_released->name_);
         else
             OE_WriteToLog("dafuq?"); /// IMPOSSIBLE
@@ -217,20 +215,27 @@ void OE_EventHandler::internalBroadcastKeyUpEvent(const std::string& name) {
     // update keyboard event if it exists
     else if (name.substr(0, 9) == "keyboard-") {
 
-        OE_KeyboardEvent* just_pressed  = static_cast<OE_KeyboardEvent*>(getIEvent(name + "+").get());
-        OE_KeyboardEvent* just_released = static_cast<OE_KeyboardEvent*>(getIEvent(name + "-").get());
-        OE_KeyboardEvent* held          = static_cast<OE_KeyboardEvent*>(getIEvent(name + "").get());
+        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(getIEvent(name + "+").get());
+        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(getIEvent(name + "-").get());
+        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(getIEvent(name + "").get());
 
-        while (just_pressed->keystate < OE_BUTTON::JUST_RELEASE) {
-            just_pressed->keystate += 1;
-            just_released->keystate += 1;
-            held->keystate += 1;
+        while (just_pressed->keystate_ < oe::BUTTON_JUST_RELEASE) {
+            just_pressed->keystate_ += 1;
+            just_released->keystate_ += 1;
+            held->keystate_ += 1;
         }
-        if (just_pressed->keystate == OE_BUTTON::JUST_RELEASE)
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_RELEASE)
             this->broadcastIEvent(just_released->name_);
         else
             OE_WriteToLog("dafuq?"); /// IMPOSSIBLE
     }
     else {
     }
+}
+
+void oe::event_handler_t::internal_update_mouse_status(int x, int y, int delta_x, int delta_y){
+    mouse_x_ = x;
+    mouse_y_ = y;
+    mouse_delta_x_ = delta_x;
+    mouse_delta_y_ = delta_y;
 }

--- a/src/Events/input_event_handler.cpp
+++ b/src/Events/input_event_handler.cpp
@@ -32,22 +32,22 @@ void oe::input_event_handler_t::createEvents(std::map<std::string, std::shared_p
 
         // event for just pressed (sent once per tap)
         shared_ptr<oe::keyboard_event_t> event = std::make_shared<oe::keyboard_event_t>();
-        event->name_                       = "keyboard-" + x.second + "+";
-        event->key_                        = x.second;
+        event->name_                           = "keyboard-" + x.second + "+";
+        event->key_                            = x.second;
         event->set_func(&template_event_func);
         event_list[0][event->name_] = event;
 
         // event for just release (sent once per release)
         shared_ptr<oe::keyboard_event_t> event1 = std::make_shared<oe::keyboard_event_t>();
-        event1->name_                       = "keyboard-" + x.second + "-";
-        event1->key_                        = x.second;
+        event1->name_                           = "keyboard-" + x.second + "-";
+        event1->key_                            = x.second;
         event1->set_func(&template_event_func);
         event_list[0][event1->name_] = event1;
 
         // event for hold (sent every frame the key is being held)
         shared_ptr<oe::keyboard_event_t> event2 = std::make_shared<oe::keyboard_event_t>();
-        event2->name_                       = "keyboard-" + x.second + "";
-        event2->key_                        = x.second;
+        event2->name_                           = "keyboard-" + x.second + "";
+        event2->key_                            = x.second;
         event2->set_func(&template_event_func);
         event_list[0][event2->name_] = event2;
     }
@@ -56,34 +56,34 @@ void oe::input_event_handler_t::createEvents(std::map<std::string, std::shared_p
     for (auto x : this->mouseList) {
         // event for just pressed (sent once per tap)
         shared_ptr<oe::mouse_event_t> event = std::make_shared<oe::mouse_event_t>();
-        event->name_                    = "mouse-" + x.second + "+";
-        event->key_                     = x.second;
+        event->name_                        = "mouse-" + x.second + "+";
+        event->key_                         = x.second;
         event->set_func(&template_event_func);
         event_list[0][event->name_] = event;
 
         // event for just release (sent once per release)
         shared_ptr<oe::mouse_event_t> event1 = std::make_shared<oe::mouse_event_t>();
-        event1->name_                    = "mouse-" + x.second + "-";
-        event1->key_                     = x.second;
+        event1->name_                        = "mouse-" + x.second + "-";
+        event1->key_                         = x.second;
         event1->set_func(&template_event_func);
         event_list[0][event1->name_] = event1;
 
         // event for hold (sent every frame the key is being held)
         shared_ptr<oe::mouse_event_t> event2 = std::make_shared<oe::mouse_event_t>();
-        event2->name_                    = "mouse-" + x.second + "";
-        event2->key_                     = x.second;
+        event2->name_                        = "mouse-" + x.second + "";
+        event2->key_                         = x.second;
         event2->set_func(&template_event_func);
         event_list[0][event2->name_] = event2;
     }
     /// generate mouse motion event
     shared_ptr<oe::mouse_move_event_t> event3 = std::make_shared<oe::mouse_move_event_t>();
-    event3->name_                    = "mouse-motion";
+    event3->name_                             = "mouse-motion";
     event3->set_func(&template_event_func);
     event_list[0][event3->name_] = event3;
 
     /// generate mouse wheel event
     shared_ptr<oe::mouse_move_event_t> event4 = std::make_shared<oe::mouse_move_event_t>();
-    event4->name_                    = "mouse-wheel";
+    event4->name_                             = "mouse-wheel";
     event4->set_func(&template_event_func);
     event_list[0][event4->name_] = event4;
 }
@@ -92,9 +92,11 @@ void oe::event_handler_t::updateInput() {
 
     for (auto key : this->input_handler.keyList) {
 
-        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "+").get());
-        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "-").get());
-        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "").get());
+        oe::keyboard_event_t* just_pressed =
+            static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "+").get());
+        oe::keyboard_event_t* just_released =
+            static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "-").get());
+        oe::keyboard_event_t* held = static_cast<oe::keyboard_event_t*>(getIEvent("keyboard-" + key.second + "").get());
 
         // if button is already pressed once, make it register continuous events
         if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) {
@@ -233,9 +235,9 @@ void oe::event_handler_t::internalBroadcastKeyUpEvent(const std::string& name) {
     }
 }
 
-void oe::event_handler_t::internal_update_mouse_status(int x, int y, int delta_x, int delta_y){
-    mouse_x_ = x;
-    mouse_y_ = y;
+void oe::event_handler_t::internal_update_mouse_status(int x, int y, int delta_x, int delta_y) {
+    mouse_x_       = x;
+    mouse_y_       = y;
     mouse_delta_x_ = delta_x;
     mouse_delta_y_ = delta_y;
 }

--- a/src/Events/input_event_handler.cpp
+++ b/src/Events/input_event_handler.cpp
@@ -4,9 +4,9 @@
 using namespace std;
 
 oe::input_event_handler_t::input_event_handler_t() {
-    mouseList = {
+    mouseList_ = {
         {SDL_BUTTON_LEFT, "1"}, {SDL_BUTTON_RIGHT, "2"}, {SDL_BUTTON_MIDDLE, "3"}, {SDL_BUTTON_X1, "4"}, {SDL_BUTTON_X2, "5"}};
-    keyList = {
+    keyList_ = {
         {SDLK_0, "0"},         {SDLK_1, "1"},           {SDLK_2, "2"},           {SDLK_3, "3"},         {SDLK_4, "4"},
         {SDLK_5, "0"},         {SDLK_6, "6"},           {SDLK_7, "7"},           {SDLK_8, "8"},         {SDLK_9, "9"},
         {SDLK_a, "a"},         {SDLK_b, "b"},           {SDLK_c, "c"},           {SDLK_d, "d"},         {SDLK_e, "e"},
@@ -25,11 +25,11 @@ oe::input_event_handler_t::input_event_handler_t() {
 oe::input_event_handler_t::~input_event_handler_t() {
 }
 
-std::map<std::string, std::shared_ptr<oe::event_t>> oe::input_event_handler_t::createEvents() {
+std::map<std::string, std::shared_ptr<oe::event_t>> oe::input_event_handler_t::create_events() {
 
     std::map<std::string, std::shared_ptr<oe::event_t>> event_list;
     /// generate keyboard events
-    for (auto x : this->keyList) {
+    for (auto x : this->keyList_) {
 
         // event for just pressed (sent once per tap)
         shared_ptr<oe::keyboard_event_t> event = std::make_shared<oe::keyboard_event_t>();
@@ -55,7 +55,7 @@ std::map<std::string, std::shared_ptr<oe::event_t>> oe::input_event_handler_t::c
     }
 
     /// generate mouse events
-    for (auto x : this->mouseList) {
+    for (auto x : this->mouseList_) {
         // event for just pressed (sent once per tap)
         shared_ptr<oe::mouse_event_t> event = std::make_shared<oe::mouse_event_t>();
         event->name_                        = "mouse-" + x.second + "+";
@@ -93,7 +93,7 @@ std::map<std::string, std::shared_ptr<oe::event_t>> oe::input_event_handler_t::c
     return event_list;
 }
 
-void oe::event_handler_t::updateInput() {
+void oe::event_handler_t::update_input() {
     lockMutex();
     for (auto key_event_elem : this->events_list_) {
         if (key_event_elem.p_->type_ == KEYBOARD_EVENT) {
@@ -104,7 +104,7 @@ void oe::event_handler_t::updateInput() {
             }
             else if (key_event->keystate_ == oe::BUTTON_PRESS) {
                 if (key_event->is_main_event_) {
-                    this->broadcastIEvent(key_event_elem.id_);
+                    this->broadcast_ievent(key_event_elem.id_);
                 }
             }
             else if (key_event->keystate_ == oe::BUTTON_JUST_RELEASE) {
@@ -121,7 +121,7 @@ void oe::event_handler_t::updateInput() {
             }
             else if (key_event->keystate_ == oe::BUTTON_PRESS) {
                 if (key_event->is_main_event_) {
-                    this->broadcastIEvent(key_event_elem.id_);
+                    this->broadcast_ievent(key_event_elem.id_);
                 }
             }
             else if (key_event->keystate_ == oe::BUTTON_JUST_RELEASE) {
@@ -138,7 +138,7 @@ void oe::event_handler_t::updateInput() {
     unlockMutex();
 }
 
-void oe::event_handler_t::internalBroadcastKeyDownEvent(const std::string& name) {
+void oe::event_handler_t::internal_register_keydown_event(const std::string& name) {
 
     if (name.length() <= 8)
         assert(name.substr(0, 6) == "mouse-");
@@ -152,36 +152,36 @@ void oe::event_handler_t::internalBroadcastKeyDownEvent(const std::string& name)
     // update mouse event if it exists
     if (name.substr(0, 6) == "mouse-") {
 
-        oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(getIEvent(name + "+").get());
-        oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(getIEvent(name + "-").get());
-        oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(getIEvent(name + "").get());
+        oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(get_ievent(name + "+").get());
+        oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(get_ievent(name + "-").get());
+        oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(get_ievent(name + "").get());
 
         if (just_pressed->keystate_ < oe::BUTTON_PRESS) {
             just_pressed->keystate_ += 1;
             just_released->keystate_ += 1;
             held->keystate_ += 1;
         }
-        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcastIEvent(just_pressed->name_);
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcast_ievent(just_pressed->name_);
     }
     // update keyboard event if it exists
     else if (name.substr(0, 9) == "keyboard-") {
 
-        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(getIEvent(name + "+").get());
-        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(getIEvent(name + "-").get());
-        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(getIEvent(name + "").get());
+        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(get_ievent(name + "+").get());
+        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(get_ievent(name + "-").get());
+        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(get_ievent(name + "").get());
 
         if (just_pressed->keystate_ < oe::BUTTON_JUST_PRESS) {
             just_pressed->keystate_ += 1;
             just_released->keystate_ += 1;
             held->keystate_ += 1;
         }
-        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcastIEvent(just_pressed->name_);
+        if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcast_ievent(just_pressed->name_);
     }
     else {
     }
 }
 
-void oe::event_handler_t::internalBroadcastKeyUpEvent(const std::string& name) {
+void oe::event_handler_t::internal_register_keyup_event(const std::string& name) {
     if (name.length() <= 8)
         assert(name.substr(0, 6) == "mouse-");
     else if (name.length() > 8)
@@ -194,9 +194,9 @@ void oe::event_handler_t::internalBroadcastKeyUpEvent(const std::string& name) {
     // update mouse event if it exists
     if (name.substr(0, 6) == "mouse-") {
 
-        oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(getIEvent(name + "+").get());
-        oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(getIEvent(name + "-").get());
-        oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(getIEvent(name + "").get());
+        oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(get_ievent(name + "+").get());
+        oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(get_ievent(name + "-").get());
+        oe::mouse_event_t* held          = static_cast<oe::mouse_event_t*>(get_ievent(name + "").get());
 
         if (just_pressed->keystate_ < oe::BUTTON_JUST_RELEASE) {
             just_pressed->keystate_ += 1;
@@ -204,16 +204,16 @@ void oe::event_handler_t::internalBroadcastKeyUpEvent(const std::string& name) {
             held->keystate_ += 1;
         }
         if (just_pressed->keystate_ == oe::BUTTON_JUST_RELEASE)
-            this->broadcastIEvent(just_released->name_);
+            this->broadcast_ievent(just_released->name_);
         else
             OE_WriteToLog("dafuq?"); /// IMPOSSIBLE
     }
     // update keyboard event if it exists
     else if (name.substr(0, 9) == "keyboard-") {
 
-        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(getIEvent(name + "+").get());
-        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(getIEvent(name + "-").get());
-        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(getIEvent(name + "").get());
+        oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(get_ievent(name + "+").get());
+        oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(get_ievent(name + "-").get());
+        oe::keyboard_event_t* held          = static_cast<oe::keyboard_event_t*>(get_ievent(name + "").get());
 
         while (just_pressed->keystate_ < oe::BUTTON_JUST_RELEASE) {
             just_pressed->keystate_ += 1;
@@ -221,7 +221,7 @@ void oe::event_handler_t::internalBroadcastKeyUpEvent(const std::string& name) {
             held->keystate_ += 1;
         }
         if (just_pressed->keystate_ == oe::BUTTON_JUST_RELEASE)
-            this->broadcastIEvent(just_released->name_);
+            this->broadcast_ievent(just_released->name_);
         else
             OE_WriteToLog("dafuq?"); /// IMPOSSIBLE
     }

--- a/src/Events/input_event_handler.cpp
+++ b/src/Events/input_event_handler.cpp
@@ -140,17 +140,8 @@ void oe::event_handler_t::update_input() {
 
 void oe::event_handler_t::internal_register_keydown_event(const std::string& name) {
 
-    if (name.length() <= 8)
-        assert(name.substr(0, 6) == "mouse-");
-    else if (name.length() > 8)
-        assert(name.substr(0, 6) == "mouse-" || name.substr(0, 9) == "keyboard-");
-    else {
-        cout << "Error invalid name in internalBroadcastKeyDwonEvent: " << name << endl;
-        assert(false);
-    }
-
     // update mouse event if it exists
-    if (name.substr(0, 6) == "mouse-") {
+    if (name.starts_with("mouse-")) {
 
         oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(get_ievent(name + "+").get());
         oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(get_ievent(name + "-").get());
@@ -164,7 +155,7 @@ void oe::event_handler_t::internal_register_keydown_event(const std::string& nam
         if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcast_ievent(just_pressed->name_);
     }
     // update keyboard event if it exists
-    else if (name.substr(0, 9) == "keyboard-") {
+    else if (name.starts_with("keyboard-")) {
 
         oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(get_ievent(name + "+").get());
         oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(get_ievent(name + "-").get());
@@ -178,21 +169,13 @@ void oe::event_handler_t::internal_register_keydown_event(const std::string& nam
         if (just_pressed->keystate_ == oe::BUTTON_JUST_PRESS) this->broadcast_ievent(just_pressed->name_);
     }
     else {
+        // TODO: Warnings
     }
 }
 
 void oe::event_handler_t::internal_register_keyup_event(const std::string& name) {
-    if (name.length() <= 8)
-        assert(name.substr(0, 6) == "mouse-");
-    else if (name.length() > 8)
-        assert(name.substr(0, 6) == "mouse-" || name.substr(0, 9) == "keyboard-");
-    else {
-        cout << "Error invalid name in internalBroadcastKeyDwonEvent: " << name << endl;
-        assert(false);
-    }
-
     // update mouse event if it exists
-    if (name.substr(0, 6) == "mouse-") {
+    if (name.starts_with("mouse-")) {
 
         oe::mouse_event_t* just_pressed  = static_cast<oe::mouse_event_t*>(get_ievent(name + "+").get());
         oe::mouse_event_t* just_released = static_cast<oe::mouse_event_t*>(get_ievent(name + "-").get());
@@ -209,7 +192,7 @@ void oe::event_handler_t::internal_register_keyup_event(const std::string& name)
             OE_WriteToLog("dafuq?"); /// IMPOSSIBLE
     }
     // update keyboard event if it exists
-    else if (name.substr(0, 9) == "keyboard-") {
+    else if (name.starts_with("keyboard-")) {
 
         oe::keyboard_event_t* just_pressed  = static_cast<oe::keyboard_event_t*>(get_ievent(name + "+").get());
         oe::keyboard_event_t* just_released = static_cast<oe::keyboard_event_t*>(get_ievent(name + "-").get());
@@ -226,6 +209,7 @@ void oe::event_handler_t::internal_register_keyup_event(const std::string& name)
             OE_WriteToLog("dafuq?"); /// IMPOSSIBLE
     }
     else {
+        // TODO: Warnings
     }
 }
 

--- a/src/Events/input_event_handler.cpp
+++ b/src/Events/input_event_handler.cpp
@@ -25,8 +25,9 @@ oe::input_event_handler_t::input_event_handler_t() {
 oe::input_event_handler_t::~input_event_handler_t() {
 }
 
-void oe::input_event_handler_t::createEvents(std::map<std::string, std::shared_ptr<oe::event_t>>* event_list) {
+std::map<std::string, std::shared_ptr<oe::event_t>> oe::input_event_handler_t::createEvents() {
 
+    std::map<std::string, std::shared_ptr<oe::event_t>> event_list;
     /// generate keyboard events
     for (auto x : this->keyList) {
 
@@ -35,21 +36,21 @@ void oe::input_event_handler_t::createEvents(std::map<std::string, std::shared_p
         event->name_                           = "keyboard-" + x.second + "+";
         event->key_                            = x.second;
         event->set_func(&template_event_func);
-        event_list[0][event->name_] = event;
+        event_list[event->name_] = event;
 
         // event for just release (sent once per release)
         shared_ptr<oe::keyboard_event_t> event1 = std::make_shared<oe::keyboard_event_t>();
         event1->name_                           = "keyboard-" + x.second + "-";
         event1->key_                            = x.second;
         event1->set_func(&template_event_func);
-        event_list[0][event1->name_] = event1;
+        event_list[event1->name_] = event1;
 
         // event for hold (sent every frame the key is being held)
         shared_ptr<oe::keyboard_event_t> event2 = std::make_shared<oe::keyboard_event_t>();
         event2->name_                           = "keyboard-" + x.second + "";
         event2->key_                            = x.second;
         event2->set_func(&template_event_func);
-        event_list[0][event2->name_] = event2;
+        event_list[event2->name_] = event2;
     }
 
     /// generate mouse events
@@ -59,33 +60,35 @@ void oe::input_event_handler_t::createEvents(std::map<std::string, std::shared_p
         event->name_                        = "mouse-" + x.second + "+";
         event->key_                         = x.second;
         event->set_func(&template_event_func);
-        event_list[0][event->name_] = event;
+        event_list[event->name_] = event;
 
         // event for just release (sent once per release)
         shared_ptr<oe::mouse_event_t> event1 = std::make_shared<oe::mouse_event_t>();
         event1->name_                        = "mouse-" + x.second + "-";
         event1->key_                         = x.second;
         event1->set_func(&template_event_func);
-        event_list[0][event1->name_] = event1;
+        event_list[event1->name_] = event1;
 
         // event for hold (sent every frame the key is being held)
         shared_ptr<oe::mouse_event_t> event2 = std::make_shared<oe::mouse_event_t>();
         event2->name_                        = "mouse-" + x.second + "";
         event2->key_                         = x.second;
         event2->set_func(&template_event_func);
-        event_list[0][event2->name_] = event2;
+        event_list[event2->name_] = event2;
     }
     /// generate mouse motion event
     shared_ptr<oe::mouse_move_event_t> event3 = std::make_shared<oe::mouse_move_event_t>();
     event3->name_                             = "mouse-motion";
     event3->set_func(&template_event_func);
-    event_list[0][event3->name_] = event3;
+    event_list[event3->name_] = event3;
 
     /// generate mouse wheel event
     shared_ptr<oe::mouse_move_event_t> event4 = std::make_shared<oe::mouse_move_event_t>();
     event4->name_                             = "mouse-wheel";
     event4->set_func(&template_event_func);
-    event_list[0][event4->name_] = event4;
+    event_list[event4->name_] = event4;
+
+    return event_list;
 }
 
 void oe::event_handler_t::updateInput() {

--- a/src/Renderer/DataHandler/render_data.cpp
+++ b/src/Renderer/DataHandler/render_data.cpp
@@ -4,23 +4,19 @@
 using namespace std;
 
 
-std::vector<float> NRE_MeshRenderData::genBoundingBoxVBO() {
-    return OE_GetBoundingBoxVertexBuffer(max_x, min_x, max_y, min_y, max_z, min_z);
-}
-
-OE_Vec4 NRE_CameraRenderData::get_position() {
+OE_Vec4 nre::camera_render_data_t::get_position() {
     return OE_Vec4(this->model_mat[3][0], this->model_mat[3][1], this->model_mat[3][2], this->model_mat[3][3]);
 }
 
-OE_Vec4 NRE_MaterialRenderData::get_mat_diffuse() {
+OE_Vec4 nre::material_render_data_t::get_mat_diffuse() {
     return OE_Vec4(this->data[0], this->data[1], this->data[2], this->data[3]);
 }
 
-float NRE_MaterialRenderData::get_mat_specular_hardness() {
+float nre::material_render_data_t::get_mat_specular_hardness() {
     return this->data[9];
 }
 
-std::vector<float> NRE_MeshRenderData::get_scaling_min_data() {
+std::vector<float> nre::mesh_render_data_t::get_scaling_min_data() {
     std::vector<float> output;
     output.reserve(4);
     output.push_back(this->min_x);
@@ -30,7 +26,7 @@ std::vector<float> NRE_MeshRenderData::get_scaling_min_data() {
     return output;
 }
 
-std::vector<float> NRE_MeshRenderData::get_scaling_max_data() {
+std::vector<float> nre::mesh_render_data_t::get_scaling_max_data() {
     std::vector<float> output;
     output.reserve(4);
     output.push_back(this->max_x);

--- a/src/Renderer/GL3/api_gl3.cpp
+++ b/src/Renderer/GL3/api_gl3.cpp
@@ -133,8 +133,9 @@ nre::gl3::api_t::api_t(nre::gpu::info_struct& backend_info) {
 nre::gl3::api_t::~api_t() {
 }
 
-void nre::gl3::api_t::update(uint32_t x_in, uint32_t y_in) {
+void nre::gl3::api_t::update(uint32_t x_in, uint32_t y_in, bool sanity_checks) {
 
+    sanity_checks_ = sanity_checks;
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     if (x_in != x_ or y_in != y_) {
         glViewport(0, 0, x_in, y_in);

--- a/src/Renderer/GL3/api_gl3.cpp
+++ b/src/Renderer/GL3/api_gl3.cpp
@@ -100,8 +100,8 @@ std::size_t NRE_GL3_ProgramData::hasUniform(std::string name) {
     return this->uniforms.size();
 }
 
-bool NRE_GL3_Program::operator==(const NRE_GL3_Program&) const {
-    return std::tie(this->vs, this->fs) == std::tie(this->vs, this->fs);
+bool NRE_GL3_Program::operator==(const NRE_GL3_Program& other) const {
+    return std::tie(this->vs, this->fs) == std::tie(other.vs, other.fs);
 }
 size_t NRE_GL3_Program::gen_hash() const {
     return this->vs.gen_hash() + this->fs.gen_hash();

--- a/src/Renderer/GL3/api_gl3.cpp
+++ b/src/Renderer/GL3/api_gl3.cpp
@@ -145,13 +145,13 @@ NRE_GL3_API::~NRE_GL3_API() {
 
 void NRE_GL3_API::update(uint32_t x_in, uint32_t y_in) {
 
-    if (x_in != nre::gpu::x or y_in != nre::gpu::y) {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (x_in != x_ or y_in != y_) {
         glViewport(0, 0, x_in, y_in);
-        nre::gpu::x = x_in;
-        nre::gpu::y = y_in;
+        x_ = x_in;
+        y_ = y_in;
     }
 
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDepthMask(GL_TRUE);
     glStencilMask(0xFF);
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -1430,9 +1430,12 @@ void NRE_GL3_API::setRenderMode(nre::gpu::RENDERMODE rendermode) {
     else {
         // TODO
     }
+}
+
+void NRE_GL3_API::use_wireframe(bool value_in) {
 #ifndef OE_PLATFORM_WEB
     if (nre::gpu::get_api() != nre::gpu::GLES) {
-        if (nre::gpu::use_wireframe) {
+        if (value_in) {
             glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
         }
         else {

--- a/src/Renderer/GL3/api_gl3.cpp
+++ b/src/Renderer/GL3/api_gl3.cpp
@@ -58,7 +58,7 @@ void APIENTRY openglCallbackFunction(GLenum source, GLenum type, GLuint id, GLen
 
 // small utility function to translate the buffer usages to something opengl understands
 // This should be different on other APIs
-GLenum NRE2GL_BufferUse(nre::gpu::BUFFER_USAGE usage) {
+GLenum nre::gl3::buffer_use(nre::gpu::BUFFER_USAGE usage) {
     GLenum buf_usage;
     switch (usage) {
     case nre::gpu::STATIC:
@@ -77,55 +77,41 @@ GLenum NRE2GL_BufferUse(nre::gpu::BUFFER_USAGE usage) {
 }
 
 // get index of a uniform block variable in a shader program
-std::size_t NRE_GL3_ProgramData::hasUniformBlock(std::string name) {
-    size_t index = 0;
-    for (auto x : this->uniform_blocks) {
-        if (x.name == name) {
-            return index;
-        }
-        index++;
-    }
-    return this->uniform_blocks.size();
+bool nre::gl3::program_data_t::has_uniform_block(const std::string& name) {
+    return this->uniform_blocks.contains(name);
 }
 
 // get index of a uniform variable in a shader program
-std::size_t NRE_GL3_ProgramData::hasUniform(std::string name) {
-    size_t index = 0;
-    for (auto x : this->uniforms) {
-        if (x.name == name) {
-            return index;
-        }
-        index++;
-    }
-    return this->uniforms.size();
+bool nre::gl3::program_data_t::has_uniform(const std::string& name) {
+    return this->uniforms.contains(name);
 }
 
-bool NRE_GL3_Program::operator==(const NRE_GL3_Program& other) const {
+bool nre::gl3::program_t::operator==(const nre::gl3::program_t& other) const {
     return std::tie(this->vs, this->fs) == std::tie(other.vs, other.fs);
 }
-size_t NRE_GL3_Program::gen_hash() const {
+size_t nre::gl3::program_t::gen_hash() const {
     return this->vs.gen_hash() + this->fs.gen_hash();
 }
 
-bool NRE_GL3_Texture::hasNotChanged(nre::gpu::TEXTURE_TYPE type_in, nre::gpu::TEXTURE_FILTER filter_in, int x_in, int y_in,
-                                    int mipmaps_in) {
+bool nre::gl3::texture_t::has_not_changed(nre::gpu::TEXTURE_TYPE type_in, nre::gpu::TEXTURE_FILTER filter_in, int x_in,
+                                          int y_in, int mipmaps_in) {
     return (this->type == type_in) and (this->filter == filter_in) and (this->x == x_in) and (this->y == y_in) and
            (this->mipmaps == mipmaps_in);
 }
 
-bool NRE_GL3_RenderBuffer::hasNotChanged(nre::gpu::TEXTURE_TYPE type_in, int x_in, int y_in) {
+bool nre::gl3::renderbuffer_t::has_not_changed(nre::gpu::TEXTURE_TYPE type_in, int x_in, int y_in) {
     return (this->type == type_in) and (this->x == x_in) and (this->y == y_in);
 }
 
 // ------------------------ API ---------------------- //
 
-std::size_t NRE_GL3_API::getVAOSize(std::size_t id) {
-    this->check_vao_id_(id, "getVAOSize");
-    return this->vbos[this->vaos[id].layout[0].vertex_buffer].size / this->vaos[id].layout[0].stride;
+std::size_t nre::gl3::api_t::get_vao_size(std::size_t id) {
+    this->check_vao_id_(id, "get_vao_size");
+    return this->vbos_[this->vaos_[id].layout[0].vertex_buffer].size / this->vaos_[id].layout[0].stride;
 }
 
 
-NRE_GL3_API::NRE_GL3_API(nre::gpu::info_struct& backend_info) {
+nre::gl3::api_t::api_t(nre::gpu::info_struct& backend_info) {
     this->vao_ibos_[0] = 0;
     major_             = backend_info.major;
     minor_             = backend_info.minor;
@@ -144,10 +130,10 @@ NRE_GL3_API::NRE_GL3_API(nre::gpu::info_struct& backend_info) {
         cout << "[NRE GL API Info] glDebugMessageCallback not available" << endl;
 }
 
-NRE_GL3_API::~NRE_GL3_API() {
+nre::gl3::api_t::~api_t() {
 }
 
-void NRE_GL3_API::update(uint32_t x_in, uint32_t y_in) {
+void nre::gl3::api_t::update(uint32_t x_in, uint32_t y_in) {
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     if (x_in != x_ or y_in != y_) {
@@ -171,39 +157,37 @@ void NRE_GL3_API::update(uint32_t x_in, uint32_t y_in) {
     }
 }
 
-void NRE_GL3_API::destroy() {
-    for (auto x : std::exchange(rbos, {}))
+void nre::gl3::api_t::destroy() {
+    for (auto x : std::exchange(rbos_, {}))
         glDeleteRenderbuffers(1, &x.second.handle);
-    for (auto x : std::exchange(vbos, {}))
+    for (auto x : std::exchange(vbos_, {}))
         glDeleteBuffers(1, &x.second.handle);
-    for (auto x : std::exchange(vaos, {}))
+    for (auto x : std::exchange(vaos_, {}))
         glDeleteVertexArrays(1, &x.second.handle);
-    for (auto x : std::exchange(ibos, {}))
+    for (auto x : std::exchange(ibos_, {}))
         glDeleteBuffers(1, &x.second.handle);
-    for (auto x : std::exchange(ubos, {}))
+    for (auto x : std::exchange(ubos_, {}))
         glDeleteBuffers(1, &x.second.handle);
-    for (auto x : std::exchange(fbos, {}))
+    for (auto x : std::exchange(fbos_, {}))
         glDeleteFramebuffers(1, &x.second.handle);
-    for (auto x : std::exchange(textures, {}))
+    for (auto x : std::exchange(textures_, {}))
         glDeleteTextures(1, &x.second.handle);
-    for (auto x : std::exchange(prog_db, {})) {
+    for (auto x : std::exchange(prog_db_, {})) {
         glDeleteProgram(x.second.handle);
     }
-    for (auto x : std::exchange(vs_db, {})) {
+    for (auto x : std::exchange(vs_db_, {})) {
         glDeleteShader(x.second);
     }
-    for (auto x : std::exchange(fs_db, {})) {
+    for (auto x : std::exchange(fs_db_, {})) {
         glDeleteShader(x.second);
     }
 }
 
-std::string NRE_GL3_API::getRenderingAPI() {
+std::string nre::gl3::api_t::get_rendering_api() {
     if (nre::gpu::get_api() == nre::gpu::GLES)
-        return "OpenGL ES 3/WebGL 2.0";
+        return "OpenGL ES 3.1+/WebGL 2.0+";
     else if (nre::gpu::get_api() == nre::gpu::GL)
-        return "OpenGL 3";
-    else if (nre::gpu::get_api() == nre::gpu::GLES2)
-        return "OpenGL ES 2/WebGL 1.0";
+        return "OpenGL 3.3+";
     else {
         return "Unknown";
     }
@@ -211,80 +195,80 @@ std::string NRE_GL3_API::getRenderingAPI() {
 
 //-------------------Handle errors--------------------------------//
 
-void NRE_GL3_API::check_rbo_id_(std::size_t id, const std::string& func) {
-    if (this->rbos.count(id) == 0) {
+void nre::gl3::api_t::check_rbo_id_(std::size_t id, const std::string& func) {
+    if (this->rbos_.count(id) == 0) {
         throw nre::gpu::invalid_render_buffer(id, func);
     }
 }
 
-void NRE_GL3_API::check_vbo_id_(std::size_t id, const std::string& func) {
-    if (this->vbos.count(id) == 0) {
+void nre::gl3::api_t::check_vbo_id_(std::size_t id, const std::string& func) {
+    if (this->vbos_.count(id) == 0) {
         throw nre::gpu::invalid_vertex_buffer(id, func);
     }
 }
-void NRE_GL3_API::check_ubo_id_(std::size_t id, const std::string& func) {
-    if (this->ubos.count(id) == 0) {
+void nre::gl3::api_t::check_ubo_id_(std::size_t id, const std::string& func) {
+    if (this->ubos_.count(id) == 0) {
         throw nre::gpu::invalid_uniform_buffer(id, func);
     }
 }
-void NRE_GL3_API::check_ibo_id_(std::size_t id, const std::string& func) {
-    if (this->ibos.count(id) == 0) {
+void nre::gl3::api_t::check_ibo_id_(std::size_t id, const std::string& func) {
+    if (this->ibos_.count(id) == 0) {
         throw nre::gpu::invalid_index_buffer(id, func);
     }
 }
 
-void NRE_GL3_API::check_vbo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
-    if (off_len > this->vbos[id].size) {
+void nre::gl3::api_t::check_vbo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
+    if (off_len > this->vbos_[id].size) {
         throw nre::gpu::invalid_buffer_offset_length(id, off_len, "vertex", func);
     }
 }
 
-void NRE_GL3_API::check_ubo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
-    if (off_len > this->ubos[id].size) {
+void nre::gl3::api_t::check_ubo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
+    if (off_len > this->ubos_[id].size) {
         throw nre::gpu::invalid_buffer_offset_length(id, off_len, "uniform", func);
     }
 }
 
-void NRE_GL3_API::check_ibo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
-    if (off_len > this->ibos[id].size) {
+void nre::gl3::api_t::check_ibo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
+    if (off_len > this->ibos_[id].size) {
         throw nre::gpu::invalid_buffer_offset_length(id, off_len, "index", func);
     }
 }
 
-void NRE_GL3_API::check_vao_id_(std::size_t id, const std::string& func) {
-    if (this->vaos.count(id) == 0) {
+void nre::gl3::api_t::check_vao_id_(std::size_t id, const std::string& func) {
+    if (this->vaos_.count(id) == 0) {
         throw nre::gpu::invalid_vertex_layout(id, func);
     }
 }
 
-void NRE_GL3_API::check_prog_id_(std::size_t id, const std::string& func) {
-    if (this->progs.count(id) == 0) {
+void nre::gl3::api_t::check_prog_id_(std::size_t id, const std::string& func) {
+    if (this->progs_.count(id) == 0) {
         throw nre::gpu::invalid_program_id(id, func);
     }
 }
 
-void NRE_GL3_API::check_prog_complete_(std::size_t id, const std::string& func) {
-    if (not this->progs[id].setup) {
+void nre::gl3::api_t::check_prog_complete_(std::size_t id, const std::string& func) {
+    if (not this->progs_[id].setup) {
         throw nre::gpu::incomplete_program(id, func);
     }
 }
 
 
-void NRE_GL3_API::check_prog_uniform_block_(std::size_t id, const std::string& name, const std::string& func) {
-    if (this->prog_db[this->progs[id]].hasUniformBlock(name) == this->prog_db[this->progs[id]].uniform_blocks.size()) {
+void nre::gl3::api_t::check_prog_uniform_block_(std::size_t id, const std::string& name, const std::string& func) {
+    if (not this->prog_db_[this->progs_[id]].has_uniform_block(name)) {
         throw nre::gpu::invalid_program_uniform_block(id, name, func);
     }
 }
 
-void NRE_GL3_API::check_prog_uniform_(std::size_t id, const std::string& name, const std::string& func) {
-    if (this->prog_db[this->progs[id]].hasUniform(name) == this->prog_db[this->progs[id]].uniforms.size()) {
+void nre::gl3::api_t::check_prog_uniform_(std::size_t id, const std::string& name, const std::string& func) {
+    if (not this->prog_db_[this->progs_[id]].has_uniform(name)) {
         throw nre::gpu::invalid_program_uniform(id, name, func);
     }
 }
 
-void NRE_GL3_API::check_prog_uniform_property_(std::size_t id, const std::string& name, std::size_t length,
-                                               const std::string& func, bool is_type_problem) {
-    auto uniform_typ = this->prog_db[this->progs[id]].uniforms[this->prog_db[this->progs[id]].hasUniform(name)].type;
+void nre::gl3::api_t::check_prog_uniform_property_(std::size_t id, const std::string& name, std::size_t length,
+                                                   const std::string& func, bool is_type_problem) {
+    auto uniform_typ = this->prog_db_[this->progs_[id]].uniforms[name].type;
     bool is_vec2     = (uniform_typ == GL_FLOAT_VEC2) and (length >= 2);
     bool is_vec3     = (uniform_typ == GL_FLOAT_VEC3) and (length >= 3);
     bool is_vec4     = (uniform_typ == GL_FLOAT_VEC4) and (length >= 4);
@@ -296,54 +280,54 @@ void NRE_GL3_API::check_prog_uniform_property_(std::size_t id, const std::string
     }
 }
 
-void NRE_GL3_API::check_vao_vbo_(std::size_t id, std::size_t vbo_id, const std::string& func) {
-    if (this->vbos.count(vbo_id) == 0) {
+void nre::gl3::api_t::check_vao_vbo_(std::size_t id, std::size_t vbo_id, const std::string& func) {
+    if (this->vbos_.count(vbo_id) == 0) {
         throw nre::gpu::invalid_vertex_layout_buffer(id, vbo_id, func);
     }
 }
 
-void NRE_GL3_API::check_fbo_id_(std::size_t id, const std::string& func) {
-    if (this->fbos.count(id) == 0) {
+void nre::gl3::api_t::check_fbo_id_(std::size_t id, const std::string& func) {
+    if (this->fbos_.count(id) == 0) {
         throw nre::gpu::invalid_framebuffer(id, func);
     }
 }
 
-void NRE_GL3_API::check_texture_id_(std::size_t id, const std::string& func) {
-    if (this->textures.count(id) == 0) {
+void nre::gl3::api_t::check_texture_id_(std::size_t id, const std::string& func) {
+    if (this->textures_.count(id) == 0) {
         throw nre::gpu::invalid_texture(id, func);
     }
 }
 
-void NRE_GL3_API::check_draw_range_(std::size_t id, std::size_t length, std::size_t offset, std::size_t count,
-                                    const std::string& func) {
+void nre::gl3::api_t::check_draw_range_(std::size_t id, std::size_t length, std::size_t offset, std::size_t count,
+                                        const std::string& func) {
     if ((offset + count) > length) {
         throw nre::gpu::invalid_draw_range(id, length, offset, count, func);
     }
 }
 
-void NRE_GL3_API::get_program_all_uniforms_(std::size_t id) {
+void nre::gl3::api_t::get_program_all_uniforms_(std::size_t id) {
 
     /// get all active uniform blocks (again)
     GLint numBlocks = 0;
-    glGetProgramiv(this->prog_db[this->progs[id]].handle, GL_ACTIVE_UNIFORM_BLOCKS, &numBlocks);
+    glGetProgramiv(this->prog_db_[this->progs_[id]].handle, GL_ACTIVE_UNIFORM_BLOCKS, &numBlocks);
     for (int ida = 0; ida < numBlocks; ida++) {
 
         GLint name_length = 0;
 
-        glGetActiveUniformBlockiv(this->prog_db[this->progs[id]].handle, ida, GL_UNIFORM_BLOCK_NAME_LENGTH, &name_length);
+        glGetActiveUniformBlockiv(this->prog_db_[this->progs_[id]].handle, ida, GL_UNIFORM_BLOCK_NAME_LENGTH, &name_length);
 
         GLchar ubo_name[name_length];
-        glGetActiveUniformBlockName(this->prog_db[this->progs[id]].handle, ida, name_length, NULL, &ubo_name[0]);
+        glGetActiveUniformBlockName(this->prog_db_[this->progs_[id]].handle, ida, name_length, NULL, &ubo_name[0]);
 
-        string actual_name = string(ubo_name);
-        auto   ubo_state   = NRE_GL3_ProgramUniformState();
-        ubo_state.name     = actual_name;
-        ubo_state.slot     = -1;
-        this->prog_db[this->progs[id]].uniform_blocks.push_back(ubo_state);
+        string actual_name                                                  = string(ubo_name);
+        auto   ubo_state                                                    = nre::gl3::program_uniform_state_t();
+        ubo_state.slot                                                      = -1;
+        this->prog_db_[this->progs_[id]].uniform_blocks[actual_name]        = ubo_state;
+        this->prog_db_[this->progs_[id]].uniform_block_indices[actual_name] = ida;
     }
 
     GLint numUniforms = 0;
-    glGetProgramiv(this->prog_db[this->progs[id]].handle, GL_ACTIVE_UNIFORMS, &numUniforms);
+    glGetProgramiv(this->prog_db_[this->progs_[id]].handle, GL_ACTIVE_UNIFORMS, &numUniforms);
     for (GLint ida = 0; ida < numUniforms; ida++) {
 
         GLint name_length = 0;
@@ -351,30 +335,29 @@ void NRE_GL3_API::get_program_all_uniforms_(std::size_t id) {
 
 #ifndef __EMSCRIPTEN__
         GLuint idb = ida;
-        glGetActiveUniformsiv(this->prog_db[this->progs[id]].handle, 1, &idb, GL_UNIFORM_NAME_LENGTH, &name_length);
+        glGetActiveUniformsiv(this->prog_db_[this->progs_[id]].handle, 1, &idb, GL_UNIFORM_NAME_LENGTH, &name_length);
 #else
 
-        glGetProgramiv(this->prog_db[this->progs[id]].handle, GL_ACTIVE_UNIFORM_MAX_LENGTH, &name_length);
+        glGetProgramiv(this->prog_db_[this->progs_[id]].handle, GL_ACTIVE_UNIFORM_MAX_LENGTH, &name_length);
         // cout << "uniforms:" << ida << " name length:" << name_length << endl;
 #endif
         GLchar uniform_name[name_length];
         GLenum var_enum;
         GLint  uniform_size;
-        glGetActiveUniform(this->prog_db[this->progs[id]].handle, ida, name_length, &name_length, &uniform_size, &var_enum,
+        glGetActiveUniform(this->prog_db_[this->progs_[id]].handle, ida, name_length, &name_length, &uniform_size, &var_enum,
                            &uniform_name[0]);
 
         string actual_name   = string(uniform_name);
-        auto   uniform_state = NRE_GL3_ProgramUniformState();
-        uniform_state.name   = actual_name;
+        auto   uniform_state = nre::gl3::program_uniform_state_t();
         uniform_state.slot   = -1;
         uniform_state.type   = var_enum;
         uniform_state.size   = uniform_size;
         // cout << uniform_state.name << " " << uniform_state.type << " " << uniform_state.size << endl;
-        this->prog_db[this->progs[id]].uniforms.push_back(uniform_state);
+        this->prog_db_[this->progs_[id]].uniforms[actual_name] = uniform_state;
     }
 }
 
-int NRE_GL3_API::teximage_internalformat_(nre::gpu::TEXTURE_TYPE type) {
+int nre::gl3::api_t::teximage_internalformat_(nre::gpu::TEXTURE_TYPE type) {
     switch (type) {
 
     case nre::gpu::FLOAT:
@@ -397,7 +380,7 @@ int NRE_GL3_API::teximage_internalformat_(nre::gpu::TEXTURE_TYPE type) {
     return GL_RGB;
 }
 
-int NRE_GL3_API::teximage_format_(nre::gpu::TEXTURE_TYPE type) {
+int nre::gl3::api_t::teximage_format_(nre::gpu::TEXTURE_TYPE type) {
     switch (type) {
     case nre::gpu::FLOAT:
         return GL_RGB32F;
@@ -419,7 +402,7 @@ int NRE_GL3_API::teximage_format_(nre::gpu::TEXTURE_TYPE type) {
     return GL_RGB;
 }
 
-int NRE_GL3_API::teximage_type_(nre::gpu::TEXTURE_TYPE type) {
+int nre::gl3::api_t::teximage_type_(nre::gpu::TEXTURE_TYPE type) {
     switch (type) {
     case nre::gpu::FLOAT:
         return GL_FLOAT;
@@ -445,88 +428,88 @@ int NRE_GL3_API::teximage_type_(nre::gpu::TEXTURE_TYPE type) {
 
 //---------------------Create Objects-----------------------------//
 
-std::size_t NRE_GL3_API::newVertexBuffer() {
-    cur_vbo++;
-    this->vbos[cur_vbo] = NRE_GL3_VertexBuffer();
-    glGenBuffers(1, &vbos[cur_vbo].handle);
-    return cur_vbo;
+std::size_t nre::gl3::api_t::new_vertex_buffer() {
+    cur_vbo_++;
+    this->vbos_[cur_vbo_] = nre::gl3::vertex_buffer_t();
+    glGenBuffers(1, &vbos_[cur_vbo_].handle);
+    return cur_vbo_;
 }
-std::size_t NRE_GL3_API::newVertexLayout() {
-    cur_vao++;
-    this->vaos[cur_vao] = NRE_GL3_VertexArray();
-    glGenVertexArrays(1, &vaos[cur_vao].handle);
-    this->vao_ibos_[vaos[cur_vao].handle] = 0;
-    return cur_vao;
+std::size_t nre::gl3::api_t::new_vertex_layout() {
+    cur_vao_++;
+    this->vaos_[cur_vao_] = nre::gl3::vertex_layout_t();
+    glGenVertexArrays(1, &vaos_[cur_vao_].handle);
+    this->vao_ibos_[vaos_[cur_vao_].handle] = 0;
+    return cur_vao_;
 }
-std::size_t NRE_GL3_API::newIndexBuffer() {
-    cur_ibo++;
-    this->ibos[cur_ibo] = NRE_GL3_IndexBuffer();
-    glGenBuffers(1, &ibos[cur_ibo].handle);
-    return cur_ibo;
+std::size_t nre::gl3::api_t::new_index_buffer() {
+    cur_ibo_++;
+    this->ibos_[cur_ibo_] = nre::gl3::index_buffer_t();
+    glGenBuffers(1, &ibos_[cur_ibo_].handle);
+    return cur_ibo_;
 }
-std::size_t NRE_GL3_API::newProgram() {
-    cur_prog++;
-    this->progs[cur_prog] = NRE_GL3_Program();
-    return cur_prog;
-}
-
-std::size_t NRE_GL3_API::newUniformBuffer() {
-    cur_ubo++;
-    this->ubos[cur_ubo] = NRE_GL3_UniformBuffer();
-    glGenBuffers(1, &ubos[cur_ubo].handle);
-    return cur_ubo;
+std::size_t nre::gl3::api_t::new_program() {
+    cur_prog_++;
+    this->progs_[cur_prog_] = nre::gl3::program_t();
+    return cur_prog_;
 }
 
-std::size_t NRE_GL3_API::newFrameBuffer() {
-    cur_fbo++;
-    this->fbos[cur_fbo] = NRE_GL3_FrameBuffer();
-    glGenFramebuffers(1, &fbos[cur_fbo].handle);
-    return cur_fbo;
+std::size_t nre::gl3::api_t::new_uniform_buffer() {
+    cur_ubo_++;
+    this->ubos_[cur_ubo_] = nre::gl3::uniform_buffer_t();
+    glGenBuffers(1, &ubos_[cur_ubo_].handle);
+    return cur_ubo_;
 }
 
-std::size_t NRE_GL3_API::newTexture() {
-    cur_texture++;
-    this->textures[cur_texture] = NRE_GL3_Texture();
-    glGenTextures(1, &textures[cur_texture].handle);
-    return cur_texture;
+std::size_t nre::gl3::api_t::new_framebuffer() {
+    cur_fbo_++;
+    this->fbos_[cur_fbo_] = nre::gl3::framebuffer_t();
+    glGenFramebuffers(1, &fbos_[cur_fbo_].handle);
+    return cur_fbo_;
 }
 
-std::size_t NRE_GL3_API::newRenderBuffer() {
-    cur_rbo++;
-    this->rbos[cur_rbo] = NRE_GL3_RenderBuffer();
-    glGenRenderbuffers(1, &rbos[cur_rbo].handle);
-    return cur_rbo;
+std::size_t nre::gl3::api_t::new_texture() {
+    cur_texture_++;
+    this->textures_[cur_texture_] = nre::gl3::texture_t();
+    glGenTextures(1, &textures_[cur_texture_].handle);
+    return cur_texture_;
+}
+
+std::size_t nre::gl3::api_t::new_renderbuffer() {
+    cur_rbo_++;
+    this->rbos_[cur_rbo_] = nre::gl3::renderbuffer_t();
+    glGenRenderbuffers(1, &rbos_[cur_rbo_].handle);
+    return cur_rbo_;
 }
 
 //--------------------Render Buffer -------------------------------//
 
-void NRE_GL3_API::setRenderBufferType(std::size_t id, nre::gpu::TEXTURE_TYPE a_type, int x, int y) {
-    this->check_rbo_id_(id, "setRenderBufferType");
+void nre::gl3::api_t::set_renderbuffer_textype(std::size_t id, nre::gpu::TEXTURE_TYPE a_type, int x, int y) {
+    this->check_rbo_id_(id, "set_renderbuffer_textype");
 
-    if (this->rbos[id].hasNotChanged(a_type, x, y)) {
+    if (this->rbos_[id].has_not_changed(a_type, x, y)) {
         return;
     }
 
-    this->rbos[id].type = a_type;
-    this->rbos[id].x    = a_type;
-    this->rbos[id].y    = a_type;
+    this->rbos_[id].type = a_type;
+    this->rbos_[id].x    = a_type;
+    this->rbos_[id].y    = a_type;
 
-    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos[id].handle);
+    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos_[id].handle);
     glRenderbufferStorage(GL_RENDERBUFFER, this->teximage_internalformat_(a_type), x, y);
 }
 
-void NRE_GL3_API::setFrameBufferRenderBuffer(std::size_t fbo_id, std::size_t rbo_id, int slot) {
-    this->check_rbo_id_(rbo_id, "setFrameBufferRenderBuffer");
-    this->check_fbo_id_(fbo_id, "setFrameBufferRenderBuffer");
+void nre::gl3::api_t::set_framebuffer_renderbuffer(std::size_t fbo_id, std::size_t rbo_id, int slot) {
+    this->check_rbo_id_(rbo_id, "set_framebuffer_renderbuffer");
+    this->check_fbo_id_(fbo_id, "set_framebuffer_renderbuffer");
 
-    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[fbo_id].handle);
-    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos[rbo_id].handle);
+    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[fbo_id].handle);
+    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
 
-    if (this->rbos[rbo_id].type != nre::gpu::DEPTHSTENCIL) {
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_RENDERBUFFER, this->rbos[rbo_id].handle);
+    if (this->rbos_[rbo_id].type != nre::gpu::DEPTHSTENCIL) {
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
     }
     else {
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, this->rbos[rbo_id].handle);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
     }
 
     if (glGetError() > 0) cout << glGetError() << endl;
@@ -534,241 +517,244 @@ void NRE_GL3_API::setFrameBufferRenderBuffer(std::size_t fbo_id, std::size_t rbo
 
 //---------------------Vertex Buffer-----------------------------//
 
-void NRE_GL3_API::setVertexBufferMemory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gl3::api_t::set_vertex_buffer_memory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_vbo_id_(id, "setVertexBufferMemory");
+    this->check_vbo_id_(id, "set_vertex_buffer_memory");
 
-    this->vbos[id].size  = memory_size;
-    this->vbos[id].usage = buf_usage;
-    if (this->active_vbo_ != this->vbos[id].handle) {
-        glBindBuffer(GL_ARRAY_BUFFER, this->vbos[id].handle);
-        this->active_vbo_ = this->vbos[id].handle;
+    this->vbos_[id].size  = memory_size;
+    this->vbos_[id].usage = buf_usage;
+    if (this->active_vbo_ != this->vbos_[id].handle) {
+        glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[id].handle);
+        this->active_vbo_ = this->vbos_[id].handle;
     }
-    glBufferData(GL_ARRAY_BUFFER, memory_size * sizeof(float), NULL, NRE2GL_BufferUse(buf_usage));
+    glBufferData(GL_ARRAY_BUFFER, memory_size * sizeof(float), NULL, nre::gl3::buffer_use(buf_usage));
 }
-void NRE_GL3_API::setVertexBufferData(std::size_t id, const std::vector<float>& v, std::size_t offset) {
+void nre::gl3::api_t::set_vertex_buffer_data(std::size_t id, const std::vector<float>& v, std::size_t offset) {
 
-    this->check_vbo_id_(id, "setVertexBufferData");
-    this->check_vbo_offset_length_(id, offset + v.size(), "setVertexBufferData");
+    this->check_vbo_id_(id, "set_vertex_buffer_data");
+    this->check_vbo_offset_length_(id, offset + v.size(), "set_vertex_buffer_data");
 
-    if (this->active_vbo_ != this->vbos[id].handle) {
-        glBindBuffer(GL_ARRAY_BUFFER, this->vbos[id].handle);
-        this->active_vbo_ = this->vbos[id].handle;
+    if (this->active_vbo_ != this->vbos_[id].handle) {
+        glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[id].handle);
+        this->active_vbo_ = this->vbos_[id].handle;
     }
     glBufferSubData(GL_ARRAY_BUFFER, static_cast<GLuint>(offset) * sizeof(float), v.size() * sizeof(float), &v[0]);
 }
 
-void NRE_GL3_API::setVertexBufferMemoryData(std::size_t id, const std::vector<float>& v, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gl3::api_t::set_vertex_buffer_memory_data(std::size_t id, const std::vector<float>& v,
+                                                    nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_vbo_id_(id, "setVertexBufferMemoryData");
+    this->check_vbo_id_(id, "set_vertex_buffer_memory_data");
 
-    this->vbos[id].size  = v.size();
-    this->vbos[id].usage = buf_usage;
-    if (this->active_vbo_ != this->vbos[id].handle) {
-        glBindBuffer(GL_ARRAY_BUFFER, this->vbos[id].handle);
-        this->active_vbo_ = this->vbos[id].handle;
+    this->vbos_[id].size  = v.size();
+    this->vbos_[id].usage = buf_usage;
+    if (this->active_vbo_ != this->vbos_[id].handle) {
+        glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[id].handle);
+        this->active_vbo_ = this->vbos_[id].handle;
     }
-    glBufferData(GL_ARRAY_BUFFER, v.size() * sizeof(float), &v[0], NRE2GL_BufferUse(buf_usage));
+    glBufferData(GL_ARRAY_BUFFER, v.size() * sizeof(float), &v[0], nre::gl3::buffer_use(buf_usage));
 }
 
-void NRE_GL3_API::deleteVertexBuffer(std::size_t id) {
-    this->check_vbo_id_(id, "deleteVertexBuffer");
+void nre::gl3::api_t::delete_vertex_buffer(std::size_t id) {
+    this->check_vbo_id_(id, "delete_vertex_buffer");
 
-    glDeleteBuffers(1, &this->vbos[id].handle);
+    glDeleteBuffers(1, &this->vbos_[id].handle);
     this->active_vbo_ = 0;
-    this->vbos.erase(id);
+    this->vbos_.erase(id);
 }
 
 //--------------------Index Buffer-------------------------------//
 
-void NRE_GL3_API::setIndexBufferMemory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gl3::api_t::set_index_buffer_memory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_ibo_id_(id, "setIndexBufferMemory");
+    this->check_ibo_id_(id, "set_index_buffer_memory");
 
-    this->ibos[id].size  = memory_size;
-    this->ibos[id].usage = buf_usage;
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[id].handle;
+    this->ibos_[id].size  = memory_size;
+    this->ibos_[id].usage = buf_usage;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[id].handle;
     }
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, memory_size * sizeof(uint32_t), NULL, NRE2GL_BufferUse(buf_usage));
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, memory_size * sizeof(uint32_t), NULL, nre::gl3::buffer_use(buf_usage));
 }
 
-void NRE_GL3_API::setIndexBufferData(std::size_t id, const std::vector<uint32_t>& v, std::size_t offset) {
+void nre::gl3::api_t::set_index_buffer_data(std::size_t id, const std::vector<uint32_t>& v, std::size_t offset) {
 
-    this->check_ibo_id_(id, "setIndexBufferData");
-    this->check_ibo_offset_length_(id, offset + v.size(), "setIndexBufferData");
+    this->check_ibo_id_(id, "set_index_buffer_data");
+    this->check_ibo_offset_length_(id, offset + v.size(), "set_index_buffer_data");
 
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[id].handle;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[id].handle;
     }
     glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, static_cast<GLuint>(offset) * sizeof(uint32_t), v.size() * sizeof(uint32_t),
                     &v[0]);
 }
 
-void NRE_GL3_API::setIndexBufferMemoryData(std::size_t id, const std::vector<uint32_t>& v, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gl3::api_t::set_index_buffer_memory_data(std::size_t id, const std::vector<uint32_t>& v,
+                                                   nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_ibo_id_(id, "setIndexBufferMemoryData");
+    this->check_ibo_id_(id, "set_index_buffer_memory_data");
 
-    this->ibos[id].size  = v.size();
-    this->ibos[id].usage = buf_usage;
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[id].handle;
+    this->ibos_[id].size  = v.size();
+    this->ibos_[id].usage = buf_usage;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[id].handle;
     }
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, v.size() * sizeof(uint32_t), &v[0], NRE2GL_BufferUse(buf_usage));
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, v.size() * sizeof(uint32_t), &v[0], nre::gl3::buffer_use(buf_usage));
 }
 
-void NRE_GL3_API::deleteIndexBuffer(std::size_t id) {
+void nre::gl3::api_t::delete_index_buffer(std::size_t id) {
 
-    this->check_ibo_id_(id, "deleteIndexBuffer");
+    this->check_ibo_id_(id, "delete_index_buffer");
 
-    glDeleteBuffers(1, &this->ibos[id].handle);
+    glDeleteBuffers(1, &this->ibos_[id].handle);
     this->vao_ibos_[this->active_vao_] = 0;
-    this->ibos.erase(id);
+    this->ibos_.erase(id);
 }
 
 //--------------------Uniform Buffer-----------------------------//
 
-void NRE_GL3_API::setUniformBufferMemory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gl3::api_t::set_uniform_buffer_memory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_ubo_id_(id, "setUniformBufferMemory");
+    this->check_ubo_id_(id, "set_uniform_buffer_memory");
 
-    this->ubos[id].size  = memory_size;
-    this->ubos[id].usage = buf_usage;
-    if (this->active_ubo_ != this->ubos[id].handle) {
-        glBindBuffer(GL_UNIFORM_BUFFER, this->ubos[id].handle);
-        this->active_ubo_ = this->ubos[id].handle;
+    this->ubos_[id].size  = memory_size;
+    this->ubos_[id].usage = buf_usage;
+    if (this->active_ubo_ != this->ubos_[id].handle) {
+        glBindBuffer(GL_UNIFORM_BUFFER, this->ubos_[id].handle);
+        this->active_ubo_ = this->ubos_[id].handle;
     }
-    glBufferData(GL_UNIFORM_BUFFER, memory_size * sizeof(float), NULL, NRE2GL_BufferUse(buf_usage));
+    glBufferData(GL_UNIFORM_BUFFER, memory_size * sizeof(float), NULL, nre::gl3::buffer_use(buf_usage));
 }
 
-void NRE_GL3_API::setUniformBufferData(std::size_t id, const std::vector<float>& v, std::size_t offset) {
+void nre::gl3::api_t::set_uniform_buffer_data(std::size_t id, const std::vector<float>& v, std::size_t offset) {
 
-    this->check_ubo_id_(id, "setUniformBufferData");
-    this->check_ubo_offset_length_(id, offset + v.size(), "setUniformBufferData");
+    this->check_ubo_id_(id, "set_uniform_buffer_data");
+    this->check_ubo_offset_length_(id, offset + v.size(), "set_uniform_buffer_data");
 
-    if (this->active_ubo_ != this->ubos[id].handle) {
-        glBindBuffer(GL_UNIFORM_BUFFER, this->ubos[id].handle);
-        this->active_ubo_ = this->ubos[id].handle;
+    if (this->active_ubo_ != this->ubos_[id].handle) {
+        glBindBuffer(GL_UNIFORM_BUFFER, this->ubos_[id].handle);
+        this->active_ubo_ = this->ubos_[id].handle;
     }
     glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLuint>(offset) * sizeof(float), v.size() * sizeof(float), &v[0]);
 }
 
-void NRE_GL3_API::setUniformBufferData(std::size_t id, const std::vector<uint32_t>& v, std::size_t offset) {
+void nre::gl3::api_t::set_uniform_buffer_data(std::size_t id, const std::vector<uint32_t>& v, std::size_t offset) {
 
-    this->check_ubo_id_(id, "setUniformBufferData");
-    this->check_ubo_offset_length_(id, offset + v.size(), "setUniformBufferData");
+    this->check_ubo_id_(id, "set_uniform_buffer_data");
+    this->check_ubo_offset_length_(id, offset + v.size(), "set_uniform_buffer_data");
 
-    if (this->active_ubo_ != this->ubos[id].handle) {
-        glBindBuffer(GL_UNIFORM_BUFFER, this->ubos[id].handle);
-        this->active_ubo_ = this->ubos[id].handle;
+    if (this->active_ubo_ != this->ubos_[id].handle) {
+        glBindBuffer(GL_UNIFORM_BUFFER, this->ubos_[id].handle);
+        this->active_ubo_ = this->ubos_[id].handle;
     }
     glBufferSubData(GL_UNIFORM_BUFFER, static_cast<GLuint>(offset) * sizeof(uint32_t), v.size() * sizeof(uint32_t), &v[0]);
 }
 
 //----------------------Uniform State ----------------//
 
-void NRE_GL3_API::setProgramTextureSlot(std::size_t id, std::string name, int slot) {
-    this->check_prog_id_(id, "setProgramTextureSlot");
-    this->check_prog_complete_(id, "setProgramUniformData");
-    this->check_prog_uniform_(id, name, "setProgramTextureSlot");
+void nre::gl3::api_t::set_program_texture_slot(std::size_t id, const std::string& name, int slot) {
+    this->check_prog_id_(id, "set_program_texture_slot");
+    this->check_prog_complete_(id, "set_program_texture_slot");
+    this->check_prog_uniform_(id, name, "set_program_texture_slot");
 
 
-    if (this->active_prog_ != this->progs[id].handle) {
-        glUseProgram(this->progs[id].handle);
-        this->active_prog_ = this->progs[id].handle;
+    if (this->active_prog_ != this->progs_[id].handle) {
+        glUseProgram(this->progs_[id].handle);
+        this->active_prog_ = this->progs_[id].handle;
     }
-    auto uniform_type_enum = this->prog_db[this->progs[id]].uniforms[this->prog_db[this->progs[id]].hasUniform(name)].type;
+    auto uniform_type_enum = this->prog_db_[this->progs_[id]].uniforms[name].type;
     if ((uniform_type_enum == GL_SAMPLER_2D) or (uniform_type_enum == GL_SAMPLER_2D_SHADOW)) {
-        glUniform1i(this->prog_db[this->progs[id]].hasUniform(name), slot);
+        glUniform1i(this->prog_db_[this->progs_[id]].uniforms[name].slot, slot);
     }
     else {
         cout << "[NRE Warning] No sampler2D uniform named '" << name << "' in program ID: " << id << "." << endl;
         OE_WriteToLog("[NRE Warning] No sampler2D uniform named '" + name + "' in program ID: " + to_string(id) + ".");
     }
 }
-void NRE_GL3_API::setProgramUniformData(std::size_t id, std::string name, uint32_t data) {
-    this->check_prog_id_(id, "setProgramUniformData");
-    this->check_prog_complete_(id, "setProgramUniformData");
-    this->check_prog_uniform_(id, name, "setProgramUniformData");
+void nre::gl3::api_t::set_program_uniform_data(std::size_t id, const std::string& name, uint32_t data) {
+    this->check_prog_id_(id, "set_program_uniform_data");
+    this->check_prog_complete_(id, "set_program_uniform_data");
+    this->check_prog_uniform_(id, name, "set_program_uniform_data");
     // TODO
 }
-void NRE_GL3_API::setProgramUniformData(std::size_t id, std::string name, std::vector<uint32_t> data) {
-    this->check_prog_id_(id, "setProgramUniformData");
-    this->check_prog_complete_(id, "setProgramUniformData");
-    this->check_prog_uniform_(id, name, "setProgramUniformData");
+void nre::gl3::api_t::set_program_uniform_data(std::size_t id, const std::string& name, std::vector<uint32_t> data) {
+    this->check_prog_id_(id, "set_program_uniform_data");
+    this->check_prog_complete_(id, "set_program_uniform_data");
+    this->check_prog_uniform_(id, name, "set_program_uniform_data");
     // TODO
 }
 
-int NRE_GL3_API::getProgramUniformSlot(std::size_t id, std::string name) {
-    this->check_prog_id_(id, "getProgramUniformSlot");
-    this->check_prog_complete_(id, "getProgramUniformSlot");
-    if (this->prog_db[this->progs[id]].hasUniform(name) != this->prog_db[this->progs[id]].uniforms.size()) {
-        return this->prog_db[this->progs[id]].uniforms[this->prog_db[this->progs[id]].hasUniform(name)].slot;
+int nre::gl3::api_t::get_program_uniform_slot(std::size_t id, const std::string& name) {
+    this->check_prog_id_(id, "get_program_uniform_slot");
+    this->check_prog_complete_(id, "get_program_uniform_slot");
+    if (this->prog_db_[this->progs_[id]].has_uniform(name)) {
+        return this->prog_db_[this->progs_[id]].uniforms[name].slot;
     }
     return -2;
 }
 
-void NRE_GL3_API::setProgramUniformBlockSlot(std::size_t id, std::string name, int slot) {
+void nre::gl3::api_t::set_program_uniform_block_slot(std::size_t id, const std::string& name, int slot) {
 
-    this->check_prog_id_(id, "setProgramUniformBlockSlot");
-    this->check_prog_complete_(id, "setProgramUniformBlockSlot");
-    this->check_prog_uniform_block_(id, name, "setProgramUniformBlockSlot");
+    this->check_prog_id_(id, "set_program_uniform_block_slot");
+    this->check_prog_complete_(id, "set_program_uniform_block_slot");
+    this->check_prog_uniform_block_(id, name, "set_program_uniform_block_slot");
 
-    this->prog_db[this->progs[id]].uniform_blocks[this->prog_db[this->progs[id]].hasUniformBlock(name)].slot = slot;
+    this->prog_db_[this->progs_[id]].uniform_blocks[name].slot = slot;
 
-    glUniformBlockBinding(this->progs[id].handle, this->prog_db[this->progs[id]].hasUniformBlock(name), slot);
+    glUniformBlockBinding(this->progs_[id].handle, this->prog_db_[this->progs_[id]].uniform_block_indices[name], slot);
 }
 
-void NRE_GL3_API::setUniformBlockState(std::size_t id, std::size_t program, int slot, std::size_t offset, std::size_t length) {
+void nre::gl3::api_t::set_uniform_block_state(std::size_t id, std::size_t program, int slot, std::size_t offset,
+                                              std::size_t length) {
 
-    this->check_ubo_id_(id, "setUniformBlockState");
-    this->check_ubo_offset_length_(id, offset + length, "setUniformBlockState");
-    this->check_prog_id_(program, "setUniformBlockState");
+    this->check_ubo_id_(id, "set_uniform_block_state");
+    this->check_ubo_offset_length_(id, offset + length, "set_uniform_block_state");
+    this->check_prog_id_(program, "set_uniform_block_state");
 
     if (length == 0)
-        glBindBufferBase(GL_UNIFORM_BUFFER, slot, this->ubos[id].handle);
+        glBindBufferBase(GL_UNIFORM_BUFFER, slot, this->ubos_[id].handle);
     else
-        glBindBufferRange(GL_UNIFORM_BUFFER, slot, this->ubos[id].handle, static_cast<GLuint>(offset),
+        glBindBufferRange(GL_UNIFORM_BUFFER, slot, this->ubos_[id].handle, static_cast<GLuint>(offset),
                           static_cast<GLuint>(length));
 }
 
-int NRE_GL3_API::getProgramUniformBlockSlot(std::size_t id, std::string name) {
-    this->check_prog_id_(id, "getProgramUniformBlockSlot");
-    this->check_prog_complete_(id, "getProgramUniformBlockSlot");
-    if (this->prog_db[this->progs[id]].hasUniformBlock(name) != this->prog_db[this->progs[id]].uniform_blocks.size()) {
-        return this->prog_db[this->progs[id]].uniform_blocks[this->prog_db[this->progs[id]].hasUniformBlock(name)].slot;
+int nre::gl3::api_t::get_program_uniform_block_slot(std::size_t id, const std::string& name) {
+    this->check_prog_id_(id, "get_program_uniform_block_slot");
+    this->check_prog_complete_(id, "get_program_uniform_block_slot");
+    if (this->prog_db_[this->progs_[id]].has_uniform_block(name)) {
+        return this->prog_db_[this->progs_[id]].uniform_blocks[name].slot;
     }
     return -2;
 }
 
-void NRE_GL3_API::deleteUniformBuffer(std::size_t id) {
+void nre::gl3::api_t::delete_uniform_buffer(std::size_t id) {
 
-    this->check_ubo_id_(id, "deleteUniformBuffer");
+    this->check_ubo_id_(id, "delete_uniform_buffer");
 
-    glDeleteBuffers(1, &this->ubos[id].handle);
+    glDeleteBuffers(1, &this->ubos_[id].handle);
     this->active_ubo_ = 0;
-    this->ubos.erase(id);
+    this->ubos_.erase(id);
 }
 
 //---------------------Vertex Layout-----------------------------//
 
-void NRE_GL3_API::setVertexLayoutFormat(std::size_t id, std::vector<nre::gpu::vertex_layout_input> inputs) {
+void nre::gl3::api_t::set_vertex_layout_format(std::size_t id, std::vector<nre::gpu::vertex_layout_input> inputs) {
 
-    this->check_vao_id_(id, "setVertexlayoutFormat");
+    this->check_vao_id_(id, "setVertexlayout_format");
 
-    this->vaos[id].layout = inputs;
-    if (this->active_vao_ != this->vaos[id].handle) {
-        glBindVertexArray(this->vaos[id].handle);
-        this->active_vao_ = this->vaos[id].handle;
+    this->vaos_[id].layout = inputs;
+    if (this->active_vao_ != this->vaos_[id].handle) {
+        glBindVertexArray(this->vaos_[id].handle);
+        this->active_vao_ = this->vaos_[id].handle;
     }
     for (size_t x = 0; x < inputs.size(); x++) {
 
-        this->check_vao_vbo_(id, inputs[x].vertex_buffer, "setVertexLayoutFormat");
+        this->check_vao_vbo_(id, inputs[x].vertex_buffer, "set_vertex_layout_format");
 
-        glBindBuffer(GL_ARRAY_BUFFER, this->vbos[inputs[x].vertex_buffer].handle);
+        glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[inputs[x].vertex_buffer].handle);
         glVertexAttribPointer(x, inputs[x].amount, GL_FLOAT, GL_FALSE, sizeof(GLfloat) * inputs[x].stride,
                               NRE_GL3_VERTEXL_LAYOUT_OFFSET(sizeof(GLfloat) * static_cast<GLuint>(inputs[x].offset)));
         glEnableVertexAttribArray(x);
@@ -776,29 +762,29 @@ void NRE_GL3_API::setVertexLayoutFormat(std::size_t id, std::vector<nre::gpu::ve
     this->active_vbo_ = 0;
 }
 
-void NRE_GL3_API::deleteVertexLayout(std::size_t id) {
-    this->check_vao_id_(id, "deleteVertexLayout");
-    glDeleteVertexArrays(1, &this->vaos[id].handle);
+void nre::gl3::api_t::delete_vertex_layout(std::size_t id) {
+    this->check_vao_id_(id, "delete_vertex_layout");
+    glDeleteVertexArrays(1, &this->vaos_[id].handle);
     this->active_vao_ = 0;
-    this->vaos.erase(id);
+    this->vaos_.erase(id);
 }
 
 //-----------------------Textures and Framebuffers -------------//
 
-void NRE_GL3_API::setTextureFormat(std::size_t id, nre::gpu::TEXTURE_TYPE type, nre::gpu::TEXTURE_FILTER filter, uint32_t x_in,
-                                   uint32_t y_in, int mipmap_count) {
-    this->check_texture_id_(id, "setTextureFormat");
+void nre::gl3::api_t::set_texture_format(std::size_t id, nre::gpu::TEXTURE_TYPE type, nre::gpu::TEXTURE_FILTER filter,
+                                         uint32_t x_in, uint32_t y_in, int mipmap_count) {
+    this->check_texture_id_(id, "set_texture_format");
 
-    if (this->textures[id].hasNotChanged(type, filter, x_in, y_in, mipmap_count)) return;
+    if (this->textures_[id].has_not_changed(type, filter, x_in, y_in, mipmap_count)) return;
 
-    this->textures[id].type    = type;
-    this->textures[id].filter  = filter;
-    this->textures[id].x       = x_in;
-    this->textures[id].y       = y_in;
-    this->textures[id].mipmaps = mipmap_count;
+    this->textures_[id].type    = type;
+    this->textures_[id].filter  = filter;
+    this->textures_[id].x       = x_in;
+    this->textures_[id].y       = y_in;
+    this->textures_[id].mipmaps = mipmap_count;
 
 
-    glBindTexture(GL_TEXTURE_2D, this->textures[id].handle);
+    glBindTexture(GL_TEXTURE_2D, this->textures_[id].handle);
     glTexImage2D(GL_TEXTURE_2D, 0, teximage_internalformat_(type), x_in, y_in, 0, teximage_format_(type), teximage_type_(type),
                  0);
     if (mipmap_count == 0 and filter == nre::gpu::LINEAR) {
@@ -815,52 +801,52 @@ void NRE_GL3_API::setTextureFormat(std::size_t id, nre::gpu::TEXTURE_TYPE type, 
     if (glGetError() > 0) cout << glGetError() << endl;
 }
 
-void NRE_GL3_API::setFrameBufferTexture(std::size_t fbo_id, std::size_t texture_id, int slot) {
-    this->check_fbo_id_(fbo_id, "setFrameBufferTexture");
-    this->check_texture_id_(texture_id, "setFrameBufferTexture");
+void nre::gl3::api_t::set_framebuffer_texture(std::size_t fbo_id, std::size_t texture_id, int slot) {
+    this->check_fbo_id_(fbo_id, "set_framebuffer_texture");
+    this->check_texture_id_(texture_id, "set_framebuffer_texture");
     assert((slot >= 0) and (slot < 3));
 
-    this->fbos[fbo_id].texture = texture_id;
+    this->fbos_[fbo_id].texture = texture_id;
 
-    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[fbo_id].handle);
-    glBindTexture(GL_TEXTURE_2D, this->textures[texture_id].handle);
+    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[fbo_id].handle);
+    glBindTexture(GL_TEXTURE_2D, this->textures_[texture_id].handle);
 
-    if (this->textures[texture_id].type != nre::gpu::DEPTHSTENCIL) {
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_TEXTURE_2D, this->textures[texture_id].handle,
+    if (this->textures_[texture_id].type != nre::gpu::DEPTHSTENCIL) {
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_TEXTURE_2D, this->textures_[texture_id].handle,
                                0);
     }
     else {
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, this->textures[texture_id].handle,
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, this->textures_[texture_id].handle,
                                0);
     }
 
     if (glGetError() > 0) cout << glGetError() << endl;
 }
 
-void NRE_GL3_API::setTextureSlot(std::size_t id, int slot) {
-    this->check_texture_id_(id, "setTextureSlot");
+void nre::gl3::api_t::set_texture_slot(std::size_t id, int slot) {
+    this->check_texture_id_(id, "set_texture_slot");
     glActiveTexture(GL_TEXTURE0 + slot);
-    glBindTexture(GL_TEXTURE_2D, this->textures[id].handle);
+    glBindTexture(GL_TEXTURE_2D, this->textures_[id].handle);
 }
 
-void NRE_GL3_API::deleteTexture(std::size_t id) {
-    this->check_texture_id_(id, "deleteTexture");
-    glDeleteTextures(1, &this->textures[id].handle);
-    this->textures.erase(id);
+void nre::gl3::api_t::delete_texture(std::size_t id) {
+    this->check_texture_id_(id, "delete_texture");
+    glDeleteTextures(1, &this->textures_[id].handle);
+    this->textures_.erase(id);
 }
 
-void NRE_GL3_API::copyFrameBuffer(std::size_t src, std::size_t target, nre::gpu::FRAMEBUFFER_COPY method) {
-    this->check_fbo_id_(src, "copyFrameBuffer");
-    this->check_texture_id_(this->fbos[src].texture, "copyFrameBuffer");
+void nre::gl3::api_t::copy_framebuffer(std::size_t src, std::size_t target, nre::gpu::FRAMEBUFFER_COPY method) {
+    this->check_fbo_id_(src, "copy_framebuffer");
+    this->check_texture_id_(this->fbos_[src].texture, "copy_framebuffer");
 
-    auto x_tmp = this->textures[this->fbos[src].texture].x;
-    auto y_tmp = this->textures[this->fbos[src].texture].y;
+    auto x_tmp = this->textures_[this->fbos_[src].texture].x;
+    auto y_tmp = this->textures_[this->fbos_[src].texture].y;
 
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, this->fbos[src].handle);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, this->fbos_[src].handle);
     if (target != 0) {
-        this->check_fbo_id_(target, "copyFrameBuffer");
-        this->check_texture_id_(this->fbos[target].texture, "copyFrameBuffer");
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, this->fbos[target].handle);
+        this->check_fbo_id_(target, "copy_framebuffer");
+        this->check_texture_id_(this->fbos_[target].texture, "copy_framebuffer");
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, this->fbos_[target].handle);
     }
     else {
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
@@ -879,10 +865,10 @@ void NRE_GL3_API::copyFrameBuffer(std::size_t src, std::size_t target, nre::gpu:
     //     cout << glGetError() << endl;
 }
 
-void NRE_GL3_API::clearFrameBuffer(std::size_t id, nre::gpu::FRAMEBUFFER_COPY clear, float alpha_value) {
-    this->check_fbo_id_(id, "clearFrameBuffer");
+void nre::gl3::api_t::clear_framebuffer(std::size_t id, nre::gpu::FRAMEBUFFER_COPY clear, float alpha_value) {
+    this->check_fbo_id_(id, "clear_framebuffer");
 
-    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[id].handle);
+    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[id].handle);
     glDepthMask(GL_TRUE);
     glColorMask(1, 1, 1, 1);
     glClearColor(0.0f, 0.0f, 0.0f, alpha_value);
@@ -904,51 +890,51 @@ void NRE_GL3_API::clearFrameBuffer(std::size_t id, nre::gpu::FRAMEBUFFER_COPY cl
     }
 }
 
-void NRE_GL3_API::useFrameBuffer(std::size_t id) {
+void nre::gl3::api_t::use_framebuffer(std::size_t id) {
     if (id != 0) {
-        this->check_fbo_id_(id, "useFrameBuffer");
-        glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[id].handle);
+        this->check_fbo_id_(id, "use_framebuffer");
+        glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[id].handle);
     }
     else {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
     }
 }
 
-void NRE_GL3_API::deleteFrameBuffer(std::size_t id) {
-    this->check_fbo_id_(id, "deleteFrameBuffer");
-    glDeleteFramebuffers(1, &this->fbos[id].handle);
-    this->fbos.erase(id);
+void nre::gl3::api_t::delete_framebuffer(std::size_t id) {
+    this->check_fbo_id_(id, "delete_framebuffer");
+    glDeleteFramebuffers(1, &this->fbos_[id].handle);
+    this->fbos_.erase(id);
 }
 
 //---------------------Shader Programs-----------------------------//
 
-void NRE_GL3_API::setProgramVS(std::size_t id, nre::gpu::vertex_shader_t vs) {
-    this->check_prog_id_(id, "setProgramVS");
+void nre::gl3::api_t::set_program_vs(std::size_t id, nre::gpu::vertex_shader_t vs) {
+    this->check_prog_id_(id, "set_program_vs");
 
-    this->progs[id].vs_setup = false;
-    this->progs[id].setup    = false;
-    this->progs[id].vs       = vs;
+    this->progs_[id].vs_setup = false;
+    this->progs_[id].setup    = false;
+    this->progs_[id].vs       = vs;
 }
-void NRE_GL3_API::setProgramFS(std::size_t id, nre::gpu::pixel_shader_t fs) {
-    this->check_prog_id_(id, "setProgramFS");
+void nre::gl3::api_t::set_program_fs(std::size_t id, nre::gpu::pixel_shader_t fs) {
+    this->check_prog_id_(id, "set_program_fs");
 
-    this->progs[id].fs_setup = false;
-    this->progs[id].setup    = false;
-    this->progs[id].fs       = fs;
+    this->progs_[id].fs_setup = false;
+    this->progs_[id].setup    = false;
+    this->progs_[id].fs       = fs;
 }
 
-void NRE_GL3_API::setProgramVS(std::size_t id, std::string data) {
+void nre::gl3::api_t::set_program_vs(std::size_t id, std::string data) {
 
     data = data + "";
-    this->check_prog_id_(id, "setProgramVS - internal");
+    this->check_prog_id_(id, "set_program_vs - internal");
     GLuint shader_id;
-    if (!this->progs[id].vs_setup)
+    if (!this->progs_[id].vs_setup)
         shader_id = glCreateShader(GL_VERTEX_SHADER);
     else
-        shader_id = this->progs[id].vs_handle;
+        shader_id = this->progs_[id].vs_handle;
 
-    this->progs[id].vs_setup  = true;
-    this->progs[id].vs_handle = shader_id;
+    this->progs_[id].vs_setup  = true;
+    this->progs_[id].vs_handle = shader_id;
 
     /// compile and attach shader
     const char* c_str = data.c_str();
@@ -968,25 +954,25 @@ void NRE_GL3_API::setProgramVS(std::size_t id, std::string data) {
         glGetShaderInfoLog(shader_id, max_length, &actual_length, log);
 
         stringstream ss;
-        ss << "[NRE GL Shader Warning] in vertex shader: " << this->progs[id].vs.info() << endl << log << endl;
+        ss << "[NRE GL Shader Warning] in vertex shader: " << this->progs_[id].vs.info() << endl << log << endl;
         cout << ss.str();
         OE_WriteToLog(ss.str());
     }
 }
 
-// void setProgramGS(std::size_t, FE_GPU_Shader){}
-void NRE_GL3_API::setProgramFS(std::size_t id, std::string data) {
+// void set_programGS(std::size_t, FE_GPU_Shader){}
+void nre::gl3::api_t::set_program_fs(std::size_t id, std::string data) {
 
     data = data + "";
-    this->check_prog_id_(id, "setProgramFS - internal");
+    this->check_prog_id_(id, "set_program_fs - internal");
     GLuint shader_id;
-    if (!this->progs[id].fs_setup)
+    if (!this->progs_[id].fs_setup)
         shader_id = glCreateShader(GL_FRAGMENT_SHADER);
     else
-        shader_id = this->progs[id].fs_handle;
+        shader_id = this->progs_[id].fs_handle;
 
-    this->progs[id].fs_setup  = true;
-    this->progs[id].fs_handle = shader_id;
+    this->progs_[id].fs_setup  = true;
+    this->progs_[id].fs_handle = shader_id;
 
     /// compile and attach shader
     const char* c_str     = data.c_str();
@@ -1005,264 +991,264 @@ void NRE_GL3_API::setProgramFS(std::size_t id, std::string data) {
         glGetShaderInfoLog(shader_id, max_length, &actual_length, log);
 
         stringstream ss;
-        ss << "[NRE GL Shader Warning] in pixel shader: " << this->progs[id].fs.info() << endl << log << endl;
+        ss << "[NRE GL Shader Warning] in pixel shader: " << this->progs_[id].fs.info() << endl << log << endl;
         cout << ss.str();
         OE_WriteToLog(ss.str());
     }
 }
 
-// void setProgramTCS(std::size_t, FE_GPU_Shader){}
-// void setProgramTES(std::size_t, FE_GPU_Shader){}
+// void set_programTCS(std::size_t, FE_GPU_Shader){}
+// void set_programTES(std::size_t, FE_GPU_Shader){}
 
-void NRE_GL3_API::setupProgram(std::size_t id) {
+void nre::gl3::api_t::setup_program(std::size_t id) {
 
-    this->check_prog_id_(id, "setupProgram");
+    this->check_prog_id_(id, "setup_program");
 
     // ignore if the program is already setup
-    if (this->progs[id].setup) return;
+    if (this->progs_[id].setup) return;
 
     // setup vertex shader
-    if (!this->progs[id].vs_setup) {
-        if (this->vs_db.count(this->progs[id].vs) == 0) {
+    if (!this->progs_[id].vs_setup) {
+        if (this->vs_db_.count(this->progs_[id].vs) == 0) {
 
             // vertex shader does not exist, make a new entry
-            this->setProgramVS(id, this->progs[id].vs.gen_shader());
-            this->vs_db[this->progs[id].vs] = this->progs[id].vs_handle;
+            this->set_program_vs(id, this->progs_[id].vs.gen_shader());
+            this->vs_db_[this->progs_[id].vs] = this->progs_[id].vs_handle;
         }
         else {
 
             // vertex shader already exists, reuse that
-            this->progs[id].vs_handle = this->vs_db[this->progs[id].vs];
-            this->progs[id].vs_setup  = true;
+            this->progs_[id].vs_handle = this->vs_db_[this->progs_[id].vs];
+            this->progs_[id].vs_setup  = true;
         }
     }
 
     // setup pixel (fragment) shader
-    if (!this->progs[id].fs_setup) {
-        if (this->fs_db.count(this->progs[id].fs) == 0) {
+    if (!this->progs_[id].fs_setup) {
+        if (this->fs_db_.count(this->progs_[id].fs) == 0) {
 
             // pixel (fragment) shader does not exist, make a new entry
-            this->setProgramFS(id, this->progs[id].fs.gen_shader());
+            this->set_program_fs(id, this->progs_[id].fs.gen_shader());
 
-            this->fs_db[this->progs[id].fs] = this->progs[id].fs_handle;
-            this->progs[id].fs_setup        = true;
+            this->fs_db_[this->progs_[id].fs] = this->progs_[id].fs_handle;
+            this->progs_[id].fs_setup         = true;
         }
         else {
 
             // pixel (fragment) shader already exists, reuse that
-            this->progs[id].fs_handle = this->fs_db[this->progs[id].fs];
-            this->progs[id].fs_setup  = true;
+            this->progs_[id].fs_handle = this->fs_db_[this->progs_[id].fs];
+            this->progs_[id].fs_setup  = true;
         }
     }
 
     // check if program already exists
-    if (this->prog_db.count(this->progs[id]) > 0) {
+    if (this->prog_db_.count(this->progs_[id]) > 0) {
 
-        this->progs[id].handle = this->prog_db[this->progs[id]].handle;
-        this->progs[id].setup  = true;
+        this->progs_[id].handle = this->prog_db_[this->progs_[id]].handle;
+        this->progs_[id].setup  = true;
         return;
     }
     else {
-        this->progs[id].handle = glCreateProgram();
-        // this->prog_db[this->progs[id]] = this->progs[id].handle;
-        this->prog_db[this->progs[id]]        = NRE_GL3_ProgramData();
-        this->prog_db[this->progs[id]].handle = this->progs[id].handle;
+        this->progs_[id].handle = glCreateProgram();
+        // this->prog_db_[this->progs_[id]] = this->progs_[id].handle;
+        this->prog_db_[this->progs_[id]]        = nre::gl3::program_data_t();
+        this->prog_db_[this->progs_[id]].handle = this->progs_[id].handle;
     }
 
     // make sure that the vertex and fragment shaders actually compile
     // in case the program does not already exist
-    assert(this->progs[id].vs_setup && this->progs[id].fs_setup);
+    assert(this->progs_[id].vs_setup && this->progs_[id].fs_setup);
 
-    glAttachShader(this->progs[id].handle, this->progs[id].vs_handle);
+    glAttachShader(this->progs_[id].handle, this->progs_[id].vs_handle);
 
     // Technically a fragment/pixel shader is optional, but it is a must in OpenGL ES
     // This should be the case sometimes (for example in the Z_PREPASS program)
     bool isES          = nre::gpu::get_api() == nre::gpu::GLES;
-    bool isUndefinedFS = this->progs[id].fs.type == nre::gpu::FS_UNDEFINED;
+    bool isUndefinedFS = this->progs_[id].fs.type == nre::gpu::FS_UNDEFINED;
 
-    if ((isES) || (!isES && !isUndefinedFS)) glAttachShader(this->progs[id].handle, this->progs[id].fs_handle);
+    if ((isES) || (!isES && !isUndefinedFS)) glAttachShader(this->progs_[id].handle, this->progs_[id].fs_handle);
 
-    glLinkProgram(this->progs[id].handle);
+    glLinkProgram(this->progs_[id].handle);
 
 
     /// IMPORTANT: check if program is linked correctly
     int parameters = -1;
-    glGetProgramiv(this->progs[id].handle, GL_LINK_STATUS, &parameters);
+    glGetProgramiv(this->progs_[id].handle, GL_LINK_STATUS, &parameters);
     if (GL_TRUE != parameters) {
 
         int  max_length    = 2048;
         int  actual_length = 0;
         char log[2048];
-        glGetProgramInfoLog(this->progs[id].handle, max_length, &actual_length, log);
+        glGetProgramInfoLog(this->progs_[id].handle, max_length, &actual_length, log);
         cout << log << endl;
         OE_WriteToLog(log);
     }
 
     /// IMPORTANT: make sure program is runnable
-    glValidateProgram(this->progs[id].handle);
+    glValidateProgram(this->progs_[id].handle);
     parameters = -1;
-    glGetProgramiv(this->progs[id].handle, GL_VALIDATE_STATUS, &parameters);
+    glGetProgramiv(this->progs_[id].handle, GL_VALIDATE_STATUS, &parameters);
     if (GL_TRUE != parameters) {
 
         int  max_length    = 2048;
         int  actual_length = 0;
         char log[2048];
-        glGetProgramInfoLog(this->progs[id].handle, max_length, &actual_length, log);
+        glGetProgramInfoLog(this->progs_[id].handle, max_length, &actual_length, log);
 
         stringstream ss;
-        ss << "[NRE GL Shader Linking Warning] with shaders: " << this->progs[id].vs.info() << " " << this->progs[id].fs.info()
-           << endl
+        ss << "[NRE GL Shader Linking Warning] with shaders: " << this->progs_[id].vs.info() << " "
+           << this->progs_[id].fs.info() << endl
            << log << endl;
         cout << ss.str();
         OE_WriteToLog(ss.str());
     }
-    glUseProgram(this->progs[id].handle);
-    this->active_prog_ = this->progs[id].handle;
+    glUseProgram(this->progs_[id].handle);
+    this->active_prog_ = this->progs_[id].handle;
 
     /// get all active uniform blocks
     this->get_program_all_uniforms_(id);
 
-    this->progs[id].setup = true;
+    this->progs_[id].setup = true;
 }
 
-void NRE_GL3_API::deleteProgram(std::size_t id) {
+void nre::gl3::api_t::delete_program(std::size_t id) {
 
-    this->check_prog_id_(id, "deleteProgram");
+    this->check_prog_id_(id, "delete_program");
 
     this->active_prog_ = 0;
-    this->progs.erase(id);
+    this->progs_.erase(id);
 }
 
 //---------------------Draw calls-----------------------------//
 
-void NRE_GL3_API::draw(std::size_t prog_id, std::size_t vao_id, int offset, int count) {
+void nre::gl3::api_t::draw(std::size_t prog_id, std::size_t vao_id, int offset, int count) {
 
     this->check_prog_id_(prog_id, "draw (non-indexed)");
     this->check_vao_id_(vao_id, "draw (non-indexed)");
-    this->check_draw_range_(vao_id, this->getVAOSize(vao_id), offset, count, "draw (non-indexed)");
-    this->setupProgram(prog_id);
+    this->check_draw_range_(vao_id, this->get_vao_size(vao_id), offset, count, "draw (non-indexed)");
+    this->setup_program(prog_id);
 
-    if (this->active_prog_ != this->progs[prog_id].handle) {
-        glUseProgram(this->progs[prog_id].handle);
-        this->active_prog_ = this->progs[prog_id].handle;
+    if (this->active_prog_ != this->progs_[prog_id].handle) {
+        glUseProgram(this->progs_[prog_id].handle);
+        this->active_prog_ = this->progs_[prog_id].handle;
     }
-    if (this->active_vao_ != this->vaos[vao_id].handle) {
-        glBindVertexArray(this->vaos[vao_id].handle);
-        this->active_vao_ = this->vaos[vao_id].handle;
+    if (this->active_vao_ != this->vaos_[vao_id].handle) {
+        glBindVertexArray(this->vaos_[vao_id].handle);
+        this->active_vao_ = this->vaos_[vao_id].handle;
         this->active_vbo_ = 0;
     }
     glDrawArrays(GL_TRIANGLES, offset, count);
 }
 
-void NRE_GL3_API::draw(std::size_t prog_id, std::size_t vao_id) {
+void nre::gl3::api_t::draw(std::size_t prog_id, std::size_t vao_id) {
 
     this->check_prog_id_(prog_id, "draw (non-indexed)");
     this->check_vao_id_(vao_id, "draw (non-indexed)");
-    this->setupProgram(prog_id);
+    this->setup_program(prog_id);
 
-    if (this->active_prog_ != this->progs[prog_id].handle) {
-        glUseProgram(this->progs[prog_id].handle);
-        this->active_prog_ = this->progs[prog_id].handle;
+    if (this->active_prog_ != this->progs_[prog_id].handle) {
+        glUseProgram(this->progs_[prog_id].handle);
+        this->active_prog_ = this->progs_[prog_id].handle;
     }
-    if (this->active_vao_ != this->vaos[vao_id].handle) {
-        glBindVertexArray(this->vaos[vao_id].handle);
-        this->active_vao_ = this->vaos[vao_id].handle;
+    if (this->active_vao_ != this->vaos_[vao_id].handle) {
+        glBindVertexArray(this->vaos_[vao_id].handle);
+        this->active_vao_ = this->vaos_[vao_id].handle;
         this->active_vbo_ = 0;
     }
-    glDrawArrays(GL_TRIANGLES, 0, this->getVAOSize(vao_id));
+    glDrawArrays(GL_TRIANGLES, 0, this->get_vao_size(vao_id));
 }
 
-void NRE_GL3_API::draw(std::size_t prog_id, std::size_t vao_id, std::size_t ibo_id, int offset, int count) {
+void nre::gl3::api_t::draw(std::size_t prog_id, std::size_t vao_id, std::size_t ibo_id, int offset, int count) {
 
     this->check_prog_id_(prog_id, "draw (indexed)");
     this->check_vao_id_(vao_id, "draw (indexed)");
     this->check_ibo_id_(ibo_id, "draw (indexed)");
-    this->check_draw_range_(vao_id, this->ibos[ibo_id].size, offset, count, "draw (indexed)");
-    this->setupProgram(prog_id);
+    this->check_draw_range_(vao_id, this->ibos_[ibo_id].size, offset, count, "draw (indexed)");
+    this->setup_program(prog_id);
 
-    if (this->active_prog_ != this->progs[prog_id].handle) {
-        glUseProgram(this->progs[prog_id].handle);
-        this->active_prog_ = this->progs[prog_id].handle;
+    if (this->active_prog_ != this->progs_[prog_id].handle) {
+        glUseProgram(this->progs_[prog_id].handle);
+        this->active_prog_ = this->progs_[prog_id].handle;
     }
-    if (this->active_vao_ != this->vaos[vao_id].handle) {
-        glBindVertexArray(this->vaos[vao_id].handle);
-        this->active_vao_ = this->vaos[vao_id].handle;
+    if (this->active_vao_ != this->vaos_[vao_id].handle) {
+        glBindVertexArray(this->vaos_[vao_id].handle);
+        this->active_vao_ = this->vaos_[vao_id].handle;
         this->active_vbo_ = 0;
     }
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[ibo_id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[ibo_id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[ibo_id].handle;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[ibo_id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[ibo_id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[ibo_id].handle;
     }
     glDrawRangeElements(GL_TRIANGLES, offset, count, 1, GL_UNSIGNED_INT, (GLvoid*)NULL);
 }
 
-void NRE_GL3_API::draw(std::size_t prog_id, std::size_t vao_id, std::size_t ibo_id) {
+void nre::gl3::api_t::draw(std::size_t prog_id, std::size_t vao_id, std::size_t ibo_id) {
 
     this->check_prog_id_(prog_id, "draw (indexed)");
     this->check_vao_id_(vao_id, "draw (indexed)");
     this->check_ibo_id_(ibo_id, "draw (indexed)");
-    this->setupProgram(prog_id);
+    this->setup_program(prog_id);
 
-    if (this->active_prog_ != this->progs[prog_id].handle) {
-        glUseProgram(this->progs[prog_id].handle);
-        this->active_prog_ = this->progs[prog_id].handle;
+    if (this->active_prog_ != this->progs_[prog_id].handle) {
+        glUseProgram(this->progs_[prog_id].handle);
+        this->active_prog_ = this->progs_[prog_id].handle;
     }
-    if (this->active_vao_ != this->vaos[vao_id].handle) {
-        glBindVertexArray(this->vaos[vao_id].handle);
-        this->active_vao_ = this->vaos[vao_id].handle;
+    if (this->active_vao_ != this->vaos_[vao_id].handle) {
+        glBindVertexArray(this->vaos_[vao_id].handle);
+        this->active_vao_ = this->vaos_[vao_id].handle;
         this->active_vbo_ = 0;
     }
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[ibo_id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[ibo_id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[ibo_id].handle;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[ibo_id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[ibo_id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[ibo_id].handle;
     }
 
-    glDrawElements(GL_TRIANGLES, this->ibos[ibo_id].size, GL_UNSIGNED_INT, (GLvoid*)NULL);
+    glDrawElements(GL_TRIANGLES, this->ibos_[ibo_id].size, GL_UNSIGNED_INT, (GLvoid*)NULL);
 }
 
-void NRE_GL3_API::draw_instanced(std::size_t prog_id, std::size_t vao_id, std::size_t instancecount) {
+void nre::gl3::api_t::draw_instanced(std::size_t prog_id, std::size_t vao_id, std::size_t instancecount) {
 
     this->check_prog_id_(prog_id, "draw (instanced-indexed)");
     this->check_vao_id_(vao_id, "draw (instanced-indexed)");
-    this->setupProgram(prog_id);
+    this->setup_program(prog_id);
 
-    if (this->active_prog_ != this->progs[prog_id].handle) {
-        glUseProgram(this->progs[prog_id].handle);
-        this->active_prog_ = this->progs[prog_id].handle;
+    if (this->active_prog_ != this->progs_[prog_id].handle) {
+        glUseProgram(this->progs_[prog_id].handle);
+        this->active_prog_ = this->progs_[prog_id].handle;
     }
-    if (this->active_vao_ != this->vaos[vao_id].handle) {
-        glBindVertexArray(this->vaos[vao_id].handle);
-        this->active_vao_ = this->vaos[vao_id].handle;
+    if (this->active_vao_ != this->vaos_[vao_id].handle) {
+        glBindVertexArray(this->vaos_[vao_id].handle);
+        this->active_vao_ = this->vaos_[vao_id].handle;
         this->active_vbo_ = 0;
     }
-    glDrawArraysInstanced(GL_TRIANGLES, 0, this->getVAOSize(vao_id), instancecount);
+    glDrawArraysInstanced(GL_TRIANGLES, 0, this->get_vao_size(vao_id), instancecount);
 }
 
-void NRE_GL3_API::draw_instanced(std::size_t prog_id, std::size_t vao_id, std::size_t ibo_id, std::size_t instancecount) {
+void nre::gl3::api_t::draw_instanced(std::size_t prog_id, std::size_t vao_id, std::size_t ibo_id, std::size_t instancecount) {
 
     this->check_prog_id_(prog_id, "draw (instanced-indexed)");
     this->check_vao_id_(vao_id, "draw (instanced-indexed)");
     this->check_ibo_id_(ibo_id, "draw (instanced-indexed)");
-    this->setupProgram(prog_id);
+    this->setup_program(prog_id);
 
-    if (this->active_prog_ != this->progs[prog_id].handle) {
-        glUseProgram(this->progs[prog_id].handle);
-        this->active_prog_ = this->progs[prog_id].handle;
+    if (this->active_prog_ != this->progs_[prog_id].handle) {
+        glUseProgram(this->progs_[prog_id].handle);
+        this->active_prog_ = this->progs_[prog_id].handle;
     }
-    if (this->active_vao_ != this->vaos[vao_id].handle) {
-        glBindVertexArray(this->vaos[vao_id].handle);
-        this->active_vao_ = this->vaos[vao_id].handle;
+    if (this->active_vao_ != this->vaos_[vao_id].handle) {
+        glBindVertexArray(this->vaos_[vao_id].handle);
+        this->active_vao_ = this->vaos_[vao_id].handle;
         this->active_vbo_ = 0;
     }
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[ibo_id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[ibo_id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[ibo_id].handle;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[ibo_id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[ibo_id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[ibo_id].handle;
     }
 
-    glDrawElementsInstanced(GL_TRIANGLES, this->ibos[ibo_id].size, GL_UNSIGNED_INT, (GLvoid*)NULL, instancecount);
+    glDrawElementsInstanced(GL_TRIANGLES, this->ibos_[ibo_id].size, GL_UNSIGNED_INT, (GLvoid*)NULL, instancecount);
 }
 
-void NRE_GL3_API::setRenderMode(nre::gpu::RENDERMODE rendermode) {
+void nre::gl3::api_t::set_render_mode(nre::gpu::RENDERMODE rendermode) {
 
     if (rendermode == nre::gpu::Z_PREPASS_BACKFACE) {
         glDisable(GL_BLEND);
@@ -1436,7 +1422,7 @@ void NRE_GL3_API::setRenderMode(nre::gpu::RENDERMODE rendermode) {
     }
 }
 
-void NRE_GL3_API::use_wireframe(bool value_in) {
+void nre::gl3::api_t::use_wireframe(bool value_in) {
 #ifndef OE_PLATFORM_WEB
     if (nre::gpu::get_api() != nre::gpu::GLES) {
         if (value_in) {

--- a/src/Renderer/GL3/api_gl3.cpp
+++ b/src/Renderer/GL3/api_gl3.cpp
@@ -127,6 +127,10 @@ std::size_t NRE_GL3_API::getVAOSize(std::size_t id) {
 
 NRE_GL3_API::NRE_GL3_API(nre::gpu::info_struct& backend_info) {
     this->vao_ibos_[0] = 0;
+    major_             = backend_info.major;
+    minor_             = backend_info.minor;
+    backend_           = backend_info.underlying_api;
+
 #ifndef OE_PLATFORM_WEB
     if (glDebugMessageCallback) {
         cout << "[NRE GL API Info] Register OpenGL debug callback " << endl;
@@ -918,14 +922,14 @@ void NRE_GL3_API::deleteFrameBuffer(std::size_t id) {
 
 //---------------------Shader Programs-----------------------------//
 
-void NRE_GL3_API::setProgramVS(std::size_t id, nre::gpu::vertex_shader vs) {
+void NRE_GL3_API::setProgramVS(std::size_t id, nre::gpu::vertex_shader_t vs) {
     this->check_prog_id_(id, "setProgramVS");
 
     this->progs[id].vs_setup = false;
     this->progs[id].setup    = false;
     this->progs[id].vs       = vs;
 }
-void NRE_GL3_API::setProgramFS(std::size_t id, nre::gpu::pixel_shader fs) {
+void NRE_GL3_API::setProgramFS(std::size_t id, nre::gpu::pixel_shader_t fs) {
     this->check_prog_id_(id, "setProgramFS");
 
     this->progs[id].fs_setup = false;

--- a/src/Renderer/GL3/api_gl3.cpp
+++ b/src/Renderer/GL3/api_gl3.cpp
@@ -100,17 +100,11 @@ std::size_t NRE_GL3_ProgramData::hasUniform(std::string name) {
     return this->uniforms.size();
 }
 
-bool NRE_GL3_Program::operator<(const NRE_GL3_Program& other) const {
-    if (this->vs < other.vs) {
-        return true;
-    }
-    else if (this->vs == other.vs) {
-        return this->fs < other.fs;
-    }
-    else {
-        return false;
-    }
-    return false;
+bool NRE_GL3_Program::operator==(const NRE_GL3_Program&) const {
+    return std::tie(this->vs, this->fs) == std::tie(this->vs, this->fs);
+}
+size_t NRE_GL3_Program::gen_hash() const {
+    return this->vs.gen_hash() + this->fs.gen_hash();
 }
 
 bool NRE_GL3_Texture::hasNotChanged(nre::gpu::TEXTURE_TYPE type_in, nre::gpu::TEXTURE_FILTER filter_in, int x_in, int y_in,

--- a/src/Renderer/GL3/shaders_gl3.cpp
+++ b/src/Renderer/GL3/shaders_gl3.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-std::string NRE_GenGL3VertexShader(nre::gpu::vertex_shader vs) {
+std::string nre::gl3::gen_vertex_shader(nre::gpu::vertex_shader_t vs) {
 
     std::string output = "\n";
 
@@ -203,10 +203,10 @@ std::string NRE_GenGL3VertexShader(nre::gpu::vertex_shader vs) {
 
 
 
-    return nre::gpu::shader_base::shader_prefix + output;
+    return nre::gpu::gen_shader_prefix() + output;
 }
 
-std::string NRE_GenGL3PixelShader(nre::gpu::pixel_shader fs) {
+std::string nre::gl3::gen_pixel_shader(nre::gpu::pixel_shader_t fs) {
 
     std::string output = "\n";
 
@@ -218,7 +218,7 @@ std::string NRE_GenGL3PixelShader(nre::gpu::pixel_shader fs) {
         output.append(NRE_Shader(in vec2 position; out vec4 fragColor;
 
                                  void main() { fragColor = vec4(vec3(0.5), 1.0); }));
-        return nre::gpu::shader_base::shader_prefix + output;
+        return nre::gpu::gen_shader_prefix() + output;
     }
     else if (fs.type == nre::gpu::FS_GAMMA) {
         output.append(NRE_Shader(in vec2 position; out vec4 fragColor;
@@ -237,7 +237,7 @@ std::string NRE_GenGL3PixelShader(nre::gpu::pixel_shader fs) {
                                      // }
                                      fragColor = vec4(pow(sampled_data.xyz, vec3(1.0 / 2.2)), sampled_data.w);
                                  }));
-        return nre::gpu::shader_base::shader_prefix + output;
+        return nre::gpu::gen_shader_prefix() + output;
     }
     else if (fs.type == nre::gpu::FS_LIGHT_INDEX) {
         output.append(NRE_Shader(flat in float instance_num;
@@ -251,7 +251,7 @@ std::string NRE_GenGL3PixelShader(nre::gpu::pixel_shader fs) {
                                  }
 
                                  ));
-        return nre::gpu::shader_base::shader_prefix + output;
+        return nre::gpu::gen_shader_prefix() + output;
     }
 
     output.append(NRE_Shader(in vec3 position; in vec3 normals;));
@@ -329,5 +329,5 @@ std::string NRE_GenGL3PixelShader(nre::gpu::pixel_shader fs) {
             void main() { fragColor = vec4(abs(normals), 1.0); }));
     }
 
-    return nre::gpu::shader_base::shader_prefix + output;
+    return nre::gpu::gen_shader_prefix() + output;
 }

--- a/src/Renderer/GLES2/api_gles2.cpp
+++ b/src/Renderer/GLES2/api_gles2.cpp
@@ -32,8 +32,8 @@ std::size_t NRE_GLES2_ProgramData::hasUniform(std::string name) {
     return this->uniforms.contains(name);
 }
 
-bool NRE_GLES2_Program::operator==(const NRE_GLES2_Program&) const {
-    return std::tie(this->vs, this->fs) == std::tie(this->vs, this->fs);
+bool NRE_GLES2_Program::operator==(const NRE_GLES2_Program& other) const {
+    return std::tie(this->vs, this->fs) == std::tie(other.vs, other.fs);
 }
 size_t NRE_GLES2_Program::gen_hash() const {
     return this->vs.gen_hash() + this->fs.gen_hash();
@@ -116,7 +116,7 @@ void NRE_GLES2_API::update(uint32_t x_in, uint32_t y_in) {
         nre::gpu::x = x_in;
         nre::gpu::y = y_in;
     }
-    // cout << this->prog_db.size() << " " << this->vs_db.size() <<  " " << this->fs_db.size() << endl;
+    cout << this->prog_db.size() << " " << this->vs_db.size() << " " << this->fs_db.size() << endl;
     glDepthMask(GL_TRUE);
     glStencilMask(0xFF);
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);

--- a/src/Renderer/GLES2/api_gles2.cpp
+++ b/src/Renderer/GLES2/api_gles2.cpp
@@ -106,10 +106,9 @@ nre::gles2::api_t::api_t(nre::gpu::info_struct& backend_info) {
 nre::gles2::api_t::~api_t() {
 }
 
-void nre::gles2::api_t::update(uint32_t x_in, uint32_t y_in) {
+void nre::gles2::api_t::update(uint32_t x_in, uint32_t y_in, bool sanity_checks) {
 
-
-
+    sanity_checks_ = sanity_checks;
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     if (x_in != x_ or y_in != y_) {
         glViewport(0, 0, x_in, y_in);
@@ -167,53 +166,62 @@ std::string nre::gles2::api_t::get_rendering_api() {
 //-------------------Handle errors--------------------------------//
 
 void nre::gles2::api_t::check_rbo_id(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->rbos_.count(id) == 0) {
         throw nre::gpu::invalid_render_buffer(id, func);
     }
 }
 
 void nre::gles2::api_t::check_vbo_id(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->vbos_.count(id) == 0) {
         throw nre::gpu::invalid_vertex_buffer(id, func);
     }
 }
 void nre::gles2::api_t::check_ibo_id(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->ibos_.count(id) == 0) {
         throw nre::gpu::invalid_index_buffer(id, func);
     }
 }
 
 void nre::gles2::api_t::check_vbo_offset_length(std::size_t id, std::size_t off_len, const std::string& func) {
+    if (not sanity_checks_) return;
     if (off_len > this->vbos_[id].size) {
         throw nre::gpu::invalid_buffer_offset_length(id, off_len, "vertex", func);
     }
 }
 
 void nre::gles2::api_t::check_ibo_offset_length(std::size_t id, std::size_t off_len, const std::string& func) {
+    if (not sanity_checks_) return;
     if (off_len > this->ibos_[id].size) {
         throw nre::gpu::invalid_buffer_offset_length(id, off_len, "index", func);
     }
 }
 
 void nre::gles2::api_t::check_vao_id(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->vaos_.count(id) == 0) {
         throw nre::gpu::invalid_vertex_layout(id, func);
     }
 }
 
 void nre::gles2::api_t::check_prog_id(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->progs_.count(id) == 0) {
         throw nre::gpu::invalid_program_id(id, func);
     }
 }
 
 void nre::gles2::api_t::check_prog_complete(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (not this->progs_[id].setup) {
         throw nre::gpu::incomplete_program(id, func);
     }
 }
 
 void nre::gles2::api_t::check_prog_uniform(std::size_t id, const std::string& name, const std::string& func) {
+    if (not sanity_checks_) return;
     if (not this->prog_db_[this->progs_[id]].has_uniform(name)) {
         throw nre::gpu::invalid_program_uniform(id, name, func);
     }
@@ -221,6 +229,7 @@ void nre::gles2::api_t::check_prog_uniform(std::size_t id, const std::string& na
 
 void nre::gles2::api_t::check_prog_uniform_property(std::size_t id, const std::string& name, std::size_t length,
                                                     const std::string& func, bool is_type_problem) {
+    if (not sanity_checks_) return;
     auto uniform_typ = this->prog_db_[this->progs_[id]].uniforms[name].type;
     bool is_vec2     = (uniform_typ == GL_FLOAT_VEC2) and (length >= 2);
     bool is_vec3     = (uniform_typ == GL_FLOAT_VEC3) and (length >= 3);
@@ -234,18 +243,21 @@ void nre::gles2::api_t::check_prog_uniform_property(std::size_t id, const std::s
 }
 
 void nre::gles2::api_t::check_vao_vbo(std::size_t id, std::size_t vbo_id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->vbos_.count(vbo_id) == 0) {
         throw nre::gpu::invalid_vertex_layout_buffer(id, vbo_id, func);
     }
 }
 
 void nre::gles2::api_t::check_fbo_id(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->fbos_.count(id) == 0) {
         throw nre::gpu::invalid_framebuffer(id, func);
     }
 }
 
 void nre::gles2::api_t::check_texture_id(std::size_t id, const std::string& func) {
+    if (not sanity_checks_) return;
     if (this->textures_.count(id) == 0) {
         throw nre::gpu::invalid_texture(id, func);
     }
@@ -253,6 +265,7 @@ void nre::gles2::api_t::check_texture_id(std::size_t id, const std::string& func
 
 void nre::gles2::api_t::check_draw_range(std::size_t id, std::size_t length, std::size_t offset, std::size_t count,
                                          const std::string& func) {
+    if (not sanity_checks_) return;
     if ((offset + count) > length) {
         throw nre::gpu::invalid_draw_range(id, length, offset, count, func);
     }

--- a/src/Renderer/GLES2/api_gles2.cpp
+++ b/src/Renderer/GLES2/api_gles2.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 // small utility function to translate the buffer usages to something opengl understands
 // This should be different on other APIs
-GLenum NRE2GLES2_BufferUse(nre::gpu::BUFFER_USAGE usage) {
+GLenum nre::gles2::buffer_use(nre::gpu::BUFFER_USAGE usage) {
     GLenum buf_usage;
     switch (usage) {
     case nre::gpu::STATIC:
@@ -28,36 +28,36 @@ GLenum NRE2GLES2_BufferUse(nre::gpu::BUFFER_USAGE usage) {
 }
 
 // get index of a uniform variable in a shader program
-std::size_t NRE_GLES2_ProgramData::hasUniform(std::string name) {
+bool nre::gles2::program_data_t::has_uniform(const std::string& name) {
     return this->uniforms.contains(name);
 }
 
-bool NRE_GLES2_Program::operator==(const NRE_GLES2_Program& other) const {
+bool nre::gles2::program_t::operator==(const nre::gles2::program_t& other) const {
     return std::tie(this->vs, this->fs) == std::tie(other.vs, other.fs);
 }
-size_t NRE_GLES2_Program::gen_hash() const {
+size_t nre::gles2::program_t::gen_hash() const {
     return this->vs.gen_hash() + this->fs.gen_hash();
 }
 
-bool NRE_GLES2_Texture::hasNotChanged(nre::gpu::TEXTURE_TYPE type_in, nre::gpu::TEXTURE_FILTER filter_in, int x_in, int y_in,
-                                      int mipmaps_in) {
-    return (this->type == type_in) and (this->filter == filter_in) and (this->x == x_in) and (this->y == y_in) and
-           (this->mipmaps == mipmaps_in);
+bool nre::gles2::texture_t::has_not_changed(nre::gpu::TEXTURE_TYPE type_in, nre::gpu::TEXTURE_FILTER filter_in, int x_in,
+                                            int y_in, int mipmaps_in) {
+    return std::tie(this->type, this->filter, this->x, this->y, this->mipmaps) ==
+           std::tie(type_in, filter_in, x_in, y_in, mipmaps_in);
 }
 
-bool NRE_GLES2_RenderBuffer::hasNotChanged(nre::gpu::TEXTURE_TYPE type_in, int x_in, int y_in) {
-    return (this->type == type_in) and (this->x == x_in) and (this->y == y_in);
+bool nre::gles2::renderbuffer_t::has_not_changed(nre::gpu::TEXTURE_TYPE type_in, int x_in, int y_in) {
+    return std::tie(this->type, this->x, this->y) == std::tie(type_in, x_in, y_in);
 }
 
 // ------------------------ API ---------------------- //
 
-std::size_t NRE_GLES2_API::getVAOSize(std::size_t id) {
-    this->check_vao_id_(id, "getVAOSize");
-    return this->vbos[this->vaos[id].layout[0].vertex_buffer].size / this->vaos[id].layout[0].stride;
+std::size_t nre::gles2::api_t::get_vao_size(std::size_t id) {
+    this->check_vao_id(id, "get_vao_size");
+    return this->vbos_[this->vaos_[id].layout[0].vertex_buffer].size / this->vaos_[id].layout[0].stride;
 }
 
 
-NRE_GLES2_API::NRE_GLES2_API(nre::gpu::info_struct& backend_info) {
+nre::gles2::api_t::api_t(nre::gpu::info_struct& backend_info) {
     this->vao_ibos_[0] = 0;
     major_             = backend_info.major;
     minor_             = backend_info.minor;
@@ -83,32 +83,30 @@ NRE_GLES2_API::NRE_GLES2_API(nre::gpu::info_struct& backend_info) {
     for (auto extension_es : extensions_split) {
 
         if (extension_es == "GL_OES_packed_depth_stencil")
-            has_oes_packed_depth_stencil = true;
+            has_oes_packed_depth_stencil_ = true;
         else if (extension_es == "GL_OES_depth24")
-            has_oes_depth24 = true;
+            has_oes_depth24_ = true;
         else if (extension_es == "GL_OES_depth_texture")
-            has_oes_depth_texture = true;
+            has_oes_depth_texture_ = true;
         else if (extension_es == "GL_EXT_color_buffer_float")
-            has_ext_color_buffer_float = true;
+            has_ext_color_buffer_float_ = true;
         else if (extension_es == "GL_EXT_color_buffer_half_float")
-            has_ext_color_buffer_half_float = true;
+            has_ext_color_buffer_half_float_ = true;
         else if (extension_es == "GL_OES_element_index_uint")
-            has_oes_element_index_uint = true;
+            has_oes_element_index_uint_ = true;
         else if (extension_es == "GL_OES_texture_float")
-            has_oes_texture_float = true;
-        else if (extension_es == "GL_OES_element_index_uint")
-            has_oes_element_index_uint = true;
+            has_oes_texture_float_ = true;
         else
             continue;
     }
 #ifdef OE_PLATFORM_WEB
-    has_oes_element_index_uint = true; // always available on webgl
+    has_oes_element_index_uint_ = true; // always available on webgl
 #endif
 }
-NRE_GLES2_API::~NRE_GLES2_API() {
+nre::gles2::api_t::~api_t() {
 }
 
-void NRE_GLES2_API::update(uint32_t x_in, uint32_t y_in) {
+void nre::gles2::api_t::update(uint32_t x_in, uint32_t y_in) {
 
 
 
@@ -118,7 +116,7 @@ void NRE_GLES2_API::update(uint32_t x_in, uint32_t y_in) {
         x_ = x_in;
         y_ = y_in;
     }
-    // cout << this->prog_db.size() << " " << this->vs_db.size() << " " << this->fs_db.size() << endl;
+    // cout << this->prog_db_.size() << " " << this->vs_db_.size() << " " << this->fs_db_.size() << endl;
     glDepthMask(GL_TRUE);
     glStencilMask(0xFF);
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -131,99 +129,99 @@ void NRE_GLES2_API::update(uint32_t x_in, uint32_t y_in) {
     for (auto x : this->vao_ibos_) {
         this->vao_ibos_[x.first] = 0;
     }
-    for (auto a_prog : this->prog_db) {
-        this->prog_db[a_prog.first].checked = false;
+    for (auto a_prog : this->prog_db_) {
+        this->prog_db_[a_prog.first].checked = false;
         for (auto uniform : a_prog.second.uniforms) {
-            this->prog_db[a_prog.first].uniforms[uniform.first].checked = false;
+            this->prog_db_[a_prog.first].uniforms[uniform.first].checked = false;
         }
     }
 }
 
-void NRE_GLES2_API::destroy() {
-    for (auto x : std::exchange(rbos, {}))
+void nre::gles2::api_t::destroy() {
+    for (auto x : std::exchange(rbos_, {}))
         glDeleteRenderbuffers(1, &x.second.handle);
-    for (auto x : std::exchange(vbos, {}))
+    for (auto x : std::exchange(vbos_, {}))
         glDeleteBuffers(1, &x.second.handle);
-    for (auto x : std::exchange(ibos, {}))
+    for (auto x : std::exchange(ibos_, {}))
         glDeleteBuffers(1, &x.second.handle);
-    for (auto x : std::exchange(fbos, {}))
+    for (auto x : std::exchange(fbos_, {}))
         glDeleteFramebuffers(1, &x.second.handle);
-    for (auto x : std::exchange(textures, {}))
+    for (auto x : std::exchange(textures_, {}))
         glDeleteTextures(1, &x.second.handle);
-    for (auto x : std::exchange(prog_db, {})) {
+    for (auto x : std::exchange(prog_db_, {})) {
         glDeleteProgram(x.second.handle);
     }
-    for (auto x : std::exchange(vs_db, {})) {
+    for (auto x : std::exchange(vs_db_, {})) {
         glDeleteShader(x.second);
     }
-    for (auto x : std::exchange(fs_db, {})) {
+    for (auto x : std::exchange(fs_db_, {})) {
         glDeleteShader(x.second);
     }
 }
 
-std::string NRE_GLES2_API::getRenderingAPI() {
+std::string nre::gles2::api_t::get_rendering_api() {
 
-    return "OpenGL ES 2";
+    return "OpenGL ES 2/WebGL 1.0";
 }
 
 //-------------------Handle errors--------------------------------//
 
-void NRE_GLES2_API::check_rbo_id_(std::size_t id, const std::string& func) {
-    if (this->rbos.count(id) == 0) {
+void nre::gles2::api_t::check_rbo_id(std::size_t id, const std::string& func) {
+    if (this->rbos_.count(id) == 0) {
         throw nre::gpu::invalid_render_buffer(id, func);
     }
 }
 
-void NRE_GLES2_API::check_vbo_id_(std::size_t id, const std::string& func) {
-    if (this->vbos.count(id) == 0) {
+void nre::gles2::api_t::check_vbo_id(std::size_t id, const std::string& func) {
+    if (this->vbos_.count(id) == 0) {
         throw nre::gpu::invalid_vertex_buffer(id, func);
     }
 }
-void NRE_GLES2_API::check_ibo_id_(std::size_t id, const std::string& func) {
-    if (this->ibos.count(id) == 0) {
+void nre::gles2::api_t::check_ibo_id(std::size_t id, const std::string& func) {
+    if (this->ibos_.count(id) == 0) {
         throw nre::gpu::invalid_index_buffer(id, func);
     }
 }
 
-void NRE_GLES2_API::check_vbo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
-    if (off_len > this->vbos[id].size) {
+void nre::gles2::api_t::check_vbo_offset_length(std::size_t id, std::size_t off_len, const std::string& func) {
+    if (off_len > this->vbos_[id].size) {
         throw nre::gpu::invalid_buffer_offset_length(id, off_len, "vertex", func);
     }
 }
 
-void NRE_GLES2_API::check_ibo_offset_length_(std::size_t id, std::size_t off_len, const std::string& func) {
-    if (off_len > this->ibos[id].size) {
+void nre::gles2::api_t::check_ibo_offset_length(std::size_t id, std::size_t off_len, const std::string& func) {
+    if (off_len > this->ibos_[id].size) {
         throw nre::gpu::invalid_buffer_offset_length(id, off_len, "index", func);
     }
 }
 
-void NRE_GLES2_API::check_vao_id_(std::size_t id, const std::string& func) {
-    if (this->vaos.count(id) == 0) {
+void nre::gles2::api_t::check_vao_id(std::size_t id, const std::string& func) {
+    if (this->vaos_.count(id) == 0) {
         throw nre::gpu::invalid_vertex_layout(id, func);
     }
 }
 
-void NRE_GLES2_API::check_prog_id_(std::size_t id, const std::string& func) {
-    if (this->progs.count(id) == 0) {
+void nre::gles2::api_t::check_prog_id(std::size_t id, const std::string& func) {
+    if (this->progs_.count(id) == 0) {
         throw nre::gpu::invalid_program_id(id, func);
     }
 }
 
-void NRE_GLES2_API::check_prog_complete_(std::size_t id, const std::string& func) {
-    if (not this->progs[id].setup) {
+void nre::gles2::api_t::check_prog_complete(std::size_t id, const std::string& func) {
+    if (not this->progs_[id].setup) {
         throw nre::gpu::incomplete_program(id, func);
     }
 }
 
-void NRE_GLES2_API::check_prog_uniform_(std::size_t id, const std::string& name, const std::string& func) {
-    if (not this->prog_db[this->progs[id]].hasUniform(name)) {
+void nre::gles2::api_t::check_prog_uniform(std::size_t id, const std::string& name, const std::string& func) {
+    if (not this->prog_db_[this->progs_[id]].has_uniform(name)) {
         throw nre::gpu::invalid_program_uniform(id, name, func);
     }
 }
 
-void NRE_GLES2_API::check_prog_uniform_property_(std::size_t id, const std::string& name, std::size_t length,
-                                                 const std::string& func, bool is_type_problem) {
-    auto uniform_typ = this->prog_db[this->progs[id]].uniforms[name].type;
+void nre::gles2::api_t::check_prog_uniform_property(std::size_t id, const std::string& name, std::size_t length,
+                                                    const std::string& func, bool is_type_problem) {
+    auto uniform_typ = this->prog_db_[this->progs_[id]].uniforms[name].type;
     bool is_vec2     = (uniform_typ == GL_FLOAT_VEC2) and (length >= 2);
     bool is_vec3     = (uniform_typ == GL_FLOAT_VEC3) and (length >= 3);
     bool is_vec4     = (uniform_typ == GL_FLOAT_VEC4) and (length >= 4);
@@ -235,59 +233,59 @@ void NRE_GLES2_API::check_prog_uniform_property_(std::size_t id, const std::stri
     }
 }
 
-void NRE_GLES2_API::check_vao_vbo_(std::size_t id, std::size_t vbo_id, const std::string& func) {
-    if (this->vbos.count(vbo_id) == 0) {
+void nre::gles2::api_t::check_vao_vbo(std::size_t id, std::size_t vbo_id, const std::string& func) {
+    if (this->vbos_.count(vbo_id) == 0) {
         throw nre::gpu::invalid_vertex_layout_buffer(id, vbo_id, func);
     }
 }
 
-void NRE_GLES2_API::check_fbo_id_(std::size_t id, const std::string& func) {
-    if (this->fbos.count(id) == 0) {
+void nre::gles2::api_t::check_fbo_id(std::size_t id, const std::string& func) {
+    if (this->fbos_.count(id) == 0) {
         throw nre::gpu::invalid_framebuffer(id, func);
     }
 }
 
-void NRE_GLES2_API::check_texture_id_(std::size_t id, const std::string& func) {
-    if (this->textures.count(id) == 0) {
+void nre::gles2::api_t::check_texture_id(std::size_t id, const std::string& func) {
+    if (this->textures_.count(id) == 0) {
         throw nre::gpu::invalid_texture(id, func);
     }
 }
 
-void NRE_GLES2_API::check_draw_range_(std::size_t id, std::size_t length, std::size_t offset, std::size_t count,
-                                      const std::string& func) {
+void nre::gles2::api_t::check_draw_range(std::size_t id, std::size_t length, std::size_t offset, std::size_t count,
+                                         const std::string& func) {
     if ((offset + count) > length) {
         throw nre::gpu::invalid_draw_range(id, length, offset, count, func);
     }
 }
 
-void NRE_GLES2_API::get_program_all_uniforms_(std::size_t id) {
+void nre::gles2::api_t::get_program_all_uniforms(std::size_t id) {
 
     GLint numUniforms = 0;
-    glGetProgramiv(this->prog_db[this->progs[id]].handle, GL_ACTIVE_UNIFORMS, &numUniforms);
+    glGetProgramiv(this->prog_db_[this->progs_[id]].handle, GL_ACTIVE_UNIFORMS, &numUniforms);
     for (GLint ida = 0; ida < numUniforms; ida++) {
 
         GLint name_length = 0;
 
-        glGetProgramiv(this->prog_db[this->progs[id]].handle, GL_ACTIVE_UNIFORM_MAX_LENGTH, &name_length);
+        glGetProgramiv(this->prog_db_[this->progs_[id]].handle, GL_ACTIVE_UNIFORM_MAX_LENGTH, &name_length);
         // cout << "uniforms:" << ida << " name length:" << name_length << endl;
 
         GLchar uniform_name[name_length];
         GLenum var_enum;
         GLint  uniform_size;
-        glGetActiveUniform(this->prog_db[this->progs[id]].handle, ida, name_length, &name_length, &uniform_size, &var_enum,
+        glGetActiveUniform(this->prog_db_[this->progs_[id]].handle, ida, name_length, &name_length, &uniform_size, &var_enum,
                            &uniform_name[0]);
 
         string actual_name   = string(uniform_name);
-        auto   uniform_state = NRE_GLES2_ProgramUniformState();
+        auto   uniform_state = nre::gles2::program_uniform_state_t();
         uniform_state.slot   = ida;
         uniform_state.type   = var_enum;
         uniform_state.size   = uniform_size;
         // cout << uniform_state.name << " " << uniform_state.type << " " << uniform_state.size << endl;
-        this->prog_db[this->progs[id]].uniforms[actual_name] = uniform_state;
+        this->prog_db_[this->progs_[id]].uniforms[actual_name] = uniform_state;
     }
 }
 
-int NRE_GLES2_API::teximage_internalformat_(nre::gpu::TEXTURE_TYPE type) {
+int nre::gles2::api_t::teximage_internalformat(nre::gpu::TEXTURE_TYPE type) {
     switch (type) {
 
     case nre::gpu::FLOAT:
@@ -319,7 +317,7 @@ int NRE_GLES2_API::teximage_internalformat_(nre::gpu::TEXTURE_TYPE type) {
     return GL_RGB;
 }
 
-int NRE_GLES2_API::teximage_format_(nre::gpu::TEXTURE_TYPE type) {
+int nre::gles2::api_t::teximage_format(nre::gpu::TEXTURE_TYPE type) {
     switch (type) {
     case nre::gpu::FLOAT:
         return GL_RGB32F;
@@ -345,7 +343,7 @@ int NRE_GLES2_API::teximage_format_(nre::gpu::TEXTURE_TYPE type) {
     return GL_RGB;
 }
 
-int NRE_GLES2_API::teximage_type_(nre::gpu::TEXTURE_TYPE type) {
+int nre::gles2::api_t::teximage_textype(nre::gpu::TEXTURE_TYPE type) {
     switch (type) {
     case nre::gpu::FLOAT:
         return GL_FLOAT;
@@ -375,85 +373,85 @@ int NRE_GLES2_API::teximage_type_(nre::gpu::TEXTURE_TYPE type) {
 
 //---------------------Create Objects-----------------------------//
 
-std::size_t NRE_GLES2_API::newVertexBuffer() {
-    cur_vbo++;
-    this->vbos[cur_vbo] = NRE_GLES2_VertexBuffer();
-    glGenBuffers(1, &vbos[cur_vbo].handle);
-    return cur_vbo;
+std::size_t nre::gles2::api_t::new_vertex_buffer() {
+    cur_vbo_++;
+    this->vbos_[cur_vbo_] = nre::gles2::vertex_buffer_t();
+    glGenBuffers(1, &vbos_[cur_vbo_].handle);
+    return cur_vbo_;
 }
-std::size_t NRE_GLES2_API::newVertexLayout() {
-    cur_vao++;
-    this->vaos[cur_vao]                   = NRE_GLES2_VertexArray();
-    this->vao_ibos_[vaos[cur_vao].handle] = 0;
-    return cur_vao;
+std::size_t nre::gles2::api_t::new_vertex_layout() {
+    cur_vao_++;
+    this->vaos_[cur_vao_]                   = nre::gles2::vertex_array_t();
+    this->vao_ibos_[vaos_[cur_vao_].handle] = 0;
+    return cur_vao_;
 }
-std::size_t NRE_GLES2_API::newIndexBuffer() {
-    cur_ibo++;
-    this->ibos[cur_ibo] = NRE_GLES2_IndexBuffer();
-    glGenBuffers(1, &ibos[cur_ibo].handle);
-    return cur_ibo;
+std::size_t nre::gles2::api_t::new_index_buffer() {
+    cur_ibo_++;
+    this->ibos_[cur_ibo_] = nre::gles2::index_buffer_t();
+    glGenBuffers(1, &ibos_[cur_ibo_].handle);
+    return cur_ibo_;
 }
-std::size_t NRE_GLES2_API::newProgram() {
-    cur_prog++;
-    this->progs[cur_prog] = NRE_GLES2_Program();
-    return cur_prog;
-}
-
-std::size_t NRE_GLES2_API::newFrameBuffer() {
-    cur_fbo++;
-    this->fbos[cur_fbo] = NRE_GLES2_FrameBuffer();
-    glGenFramebuffers(1, &fbos[cur_fbo].handle);
-    return cur_fbo;
+std::size_t nre::gles2::api_t::new_program() {
+    cur_prog_++;
+    this->progs_[cur_prog_] = nre::gles2::program_t();
+    return cur_prog_;
 }
 
-std::size_t NRE_GLES2_API::newTexture() {
-    cur_texture++;
-    this->textures[cur_texture] = NRE_GLES2_Texture();
-    glGenTextures(1, &textures[cur_texture].handle);
-    return cur_texture;
+std::size_t nre::gles2::api_t::new_framebuffer() {
+    cur_fbo_++;
+    this->fbos_[cur_fbo_] = nre::gles2::framebuffer_t();
+    glGenFramebuffers(1, &fbos_[cur_fbo_].handle);
+    return cur_fbo_;
 }
 
-std::size_t NRE_GLES2_API::newRenderBuffer() {
-    cur_rbo++;
-    this->rbos[cur_rbo] = NRE_GLES2_RenderBuffer();
-    glGenRenderbuffers(1, &rbos[cur_rbo].handle);
-    return cur_rbo;
+std::size_t nre::gles2::api_t::new_texture() {
+    cur_texture_++;
+    this->textures_[cur_texture_] = nre::gles2::texture_t();
+    glGenTextures(1, &textures_[cur_texture_].handle);
+    return cur_texture_;
+}
+
+std::size_t nre::gles2::api_t::new_renderbuffer() {
+    cur_rbo_++;
+    this->rbos_[cur_rbo_] = nre::gles2::renderbuffer_t();
+    glGenRenderbuffers(1, &rbos_[cur_rbo_].handle);
+    return cur_rbo_;
 }
 
 //--------------------Render Buffer -------------------------------//
 
-void NRE_GLES2_API::setRenderBufferType(std::size_t id, nre::gpu::TEXTURE_TYPE a_type, int x, int y) {
-    this->check_rbo_id_(id, "setRenderBufferType");
+void nre::gles2::api_t::set_renderbuffer_textype(std::size_t id, nre::gpu::TEXTURE_TYPE a_type, int x, int y) {
+    this->check_rbo_id(id, "set_renderbuffer_textype");
 
-    if (this->rbos[id].hasNotChanged(a_type, x, y)) {
+    if (this->rbos_[id].has_not_changed(a_type, x, y)) {
         return;
     }
 
-    this->rbos[id].type = a_type;
-    this->rbos[id].x    = a_type;
-    this->rbos[id].y    = a_type;
+    this->rbos_[id].type = a_type;
+    this->rbos_[id].x    = a_type;
+    this->rbos_[id].y    = a_type;
 
-    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos[id].handle);
-    glRenderbufferStorage(GL_RENDERBUFFER, this->teximage_internalformat_(a_type), x, y);
+    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos_[id].handle);
+    glRenderbufferStorage(GL_RENDERBUFFER, this->teximage_internalformat(a_type), x, y);
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::setFrameBufferRenderBuffer(std::size_t fbo_id, std::size_t rbo_id, int slot) {
-    this->check_rbo_id_(rbo_id, "setFrameBufferRenderBuffer");
-    this->check_fbo_id_(fbo_id, "setFrameBufferRenderBuffer");
+void nre::gles2::api_t::set_framebuffer_renderbuffer(std::size_t fbo_id, std::size_t rbo_id, int slot) {
+    this->check_rbo_id(rbo_id, "set_framebuffer_renderbuffer");
+    this->check_fbo_id(fbo_id, "set_framebuffer_renderbuffer");
 
-    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[fbo_id].handle);
-    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos[rbo_id].handle);
+    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[fbo_id].handle);
+    glBindRenderbuffer(GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
 
-    if (this->rbos[rbo_id].type != nre::gpu::DEPTHSTENCIL) {
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_RENDERBUFFER, this->rbos[rbo_id].handle);
+    if (this->rbos_[rbo_id].type != nre::gpu::DEPTHSTENCIL) {
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
     }
     else {
 #ifdef OE_PLATFORM_WEB
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, this->rbos[rbo_id].handle);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
 #else
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, this->rbos[rbo_id].handle);
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, this->rbos[rbo_id].handle);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, this->rbos_[rbo_id].handle);
 #endif
     }
 
@@ -462,106 +460,108 @@ void NRE_GLES2_API::setFrameBufferRenderBuffer(std::size_t fbo_id, std::size_t r
 
 //---------------------Vertex Buffer-----------------------------//
 
-void NRE_GLES2_API::setVertexBufferMemory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gles2::api_t::set_vertex_buffer_memory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_vbo_id_(id, "setVertexBufferMemory");
+    this->check_vbo_id(id, "set_vertex_buffer_memory");
 
-    this->vbos[id].size  = memory_size;
-    this->vbos[id].usage = buf_usage;
-    if (this->active_vbo_ != this->vbos[id].handle) {
-        glBindBuffer(GL_ARRAY_BUFFER, this->vbos[id].handle);
-        this->active_vbo_ = this->vbos[id].handle;
+    this->vbos_[id].size  = memory_size;
+    this->vbos_[id].usage = buf_usage;
+    if (this->active_vbo_ != this->vbos_[id].handle) {
+        glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[id].handle);
+        this->active_vbo_ = this->vbos_[id].handle;
     }
-    glBufferData(GL_ARRAY_BUFFER, memory_size * sizeof(float), NULL, NRE2GLES2_BufferUse(buf_usage));
+    glBufferData(GL_ARRAY_BUFFER, memory_size * sizeof(float), NULL, nre::gles2::buffer_use(buf_usage));
 }
-void NRE_GLES2_API::setVertexBufferData(std::size_t id, const std::vector<float>& v, std::size_t offset) {
+void nre::gles2::api_t::set_vertex_buffer_data(std::size_t id, const std::vector<float>& v, std::size_t offset) {
 
-    this->check_vbo_id_(id, "setVertexBufferData");
-    this->check_vbo_offset_length_(id, offset + v.size(), "setVertexBufferData");
+    this->check_vbo_id(id, "set_vertex_buffer_data");
+    this->check_vbo_offset_length(id, offset + v.size(), "set_vertex_buffer_data");
 
-    if (this->active_vbo_ != this->vbos[id].handle) {
-        glBindBuffer(GL_ARRAY_BUFFER, this->vbos[id].handle);
-        this->active_vbo_ = this->vbos[id].handle;
+    if (this->active_vbo_ != this->vbos_[id].handle) {
+        glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[id].handle);
+        this->active_vbo_ = this->vbos_[id].handle;
     }
     glBufferSubData(GL_ARRAY_BUFFER, static_cast<GLuint>(offset) * sizeof(float), v.size() * sizeof(float), &v[0]);
 }
 
-void NRE_GLES2_API::setVertexBufferMemoryData(std::size_t id, const std::vector<float>& v, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gles2::api_t::set_vertex_buffer_memory_data(std::size_t id, const std::vector<float>& v,
+                                                      nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_vbo_id_(id, "setVertexBufferMemoryData");
+    this->check_vbo_id(id, "set_vertex_buffer_memory_data");
 
-    this->vbos[id].size  = v.size();
-    this->vbos[id].usage = buf_usage;
-    if (this->active_vbo_ != this->vbos[id].handle) {
-        glBindBuffer(GL_ARRAY_BUFFER, this->vbos[id].handle);
-        this->active_vbo_ = this->vbos[id].handle;
+    this->vbos_[id].size  = v.size();
+    this->vbos_[id].usage = buf_usage;
+    if (this->active_vbo_ != this->vbos_[id].handle) {
+        glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[id].handle);
+        this->active_vbo_ = this->vbos_[id].handle;
     }
-    glBufferData(GL_ARRAY_BUFFER, v.size() * sizeof(float), &v[0], NRE2GLES2_BufferUse(buf_usage));
+    glBufferData(GL_ARRAY_BUFFER, v.size() * sizeof(float), &v[0], nre::gles2::buffer_use(buf_usage));
 }
 
-void NRE_GLES2_API::deleteVertexBuffer(std::size_t id) {
-    this->check_vbo_id_(id, "deleteVertexBuffer");
+void nre::gles2::api_t::delete_vertex_buffer(std::size_t id) {
+    this->check_vbo_id(id, "delete_vertex_buffer");
 
-    glDeleteBuffers(1, &this->vbos[id].handle);
+    glDeleteBuffers(1, &this->vbos_[id].handle);
     this->active_vbo_ = 0;
-    this->vbos.erase(id);
+    this->vbos_.erase(id);
 }
 
 //--------------------Index Buffer-------------------------------//
 
-void NRE_GLES2_API::setIndexBufferMemory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gles2::api_t::set_index_buffer_memory(std::size_t id, std::size_t memory_size, nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_ibo_id_(id, "setIndexBufferMemory");
+    this->check_ibo_id(id, "set_index_buffer_memory");
 
-    this->ibos[id].size  = memory_size;
-    this->ibos[id].usage = buf_usage;
-    this->ibos[id].type_ = GL_UNSIGNED_INT;
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[id].handle;
+    this->ibos_[id].size  = memory_size;
+    this->ibos_[id].usage = buf_usage;
+    this->ibos_[id].type_ = GL_UNSIGNED_INT;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[id].handle;
     }
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, memory_size * sizeof(uint32_t), NULL, NRE2GLES2_BufferUse(buf_usage));
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, memory_size * sizeof(uint32_t), NULL, nre::gles2::buffer_use(buf_usage));
 }
 
-void NRE_GLES2_API::setIndexBufferData(std::size_t id, const std::vector<uint32_t>& v, std::size_t offset) {
+void nre::gles2::api_t::set_index_buffer_data(std::size_t id, const std::vector<uint32_t>& v, std::size_t offset) {
 
-    this->check_ibo_id_(id, "setIndexBufferData");
-    this->check_ibo_offset_length_(id, offset + v.size(), "setIndexBufferData");
+    this->check_ibo_id(id, "set_index_buffer_data");
+    this->check_ibo_offset_length(id, offset + v.size(), "set_index_buffer_data");
 
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[id].handle;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[id].handle;
     }
     glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, static_cast<GLuint>(offset) * sizeof(uint32_t), v.size() * sizeof(uint32_t),
                     &v[0]);
 }
 
-void NRE_GLES2_API::setIndexBufferMemoryData(std::size_t id, const std::vector<uint32_t>& v, nre::gpu::BUFFER_USAGE buf_usage) {
+void nre::gles2::api_t::set_index_buffer_memory_data(std::size_t id, const std::vector<uint32_t>& v,
+                                                     nre::gpu::BUFFER_USAGE buf_usage) {
 
-    this->check_ibo_id_(id, "setIndexBufferMemoryData");
+    this->check_ibo_id(id, "set_index_buffer_memory_data");
 
-    this->ibos[id].size  = v.size();
-    this->ibos[id].usage = buf_usage;
+    this->ibos_[id].size  = v.size();
+    this->ibos_[id].usage = buf_usage;
     if (v.size() == 0) {
         return;
     }
 
-    if (this->vao_ibos_[this->active_vao_] != this->ibos[id].handle) {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[id].handle);
-        this->vao_ibos_[this->active_vao_] = this->ibos[id].handle;
+    if (this->vao_ibos_[this->active_vao_] != this->ibos_[id].handle) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[id].handle);
+        this->vao_ibos_[this->active_vao_] = this->ibos_[id].handle;
     }
-    if ((*std::max_element(v.begin(), v.end()) >= 65536) and has_oes_element_index_uint) {
+    if ((*std::max_element(v.begin(), v.end()) >= 65536) and has_oes_element_index_uint_) {
         // 32-bit index buffer needed
-        this->ibos[id].type_ = GL_UNSIGNED_INT;
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, v.size() * sizeof(uint32_t), &v[0], NRE2GLES2_BufferUse(buf_usage));
+        this->ibos_[id].type_ = GL_UNSIGNED_INT;
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, v.size() * sizeof(uint32_t), &v[0], nre::gles2::buffer_use(buf_usage));
     }
-    else if (not has_oes_element_index_uint) {
+    else if (not has_oes_element_index_uint_) {
         cout << "NRE WARNING: 32-bit index buffers are not supported on this GPU. Please split your mesh into smaller ones."
              << endl;
     }
     else {
         // optimization to 16-bit buffer can happen
-        this->ibos[id].type_ = GL_UNSIGNED_SHORT;
+        this->ibos_[id].type_ = GL_UNSIGNED_SHORT;
 
         // copy to 16-bit buffer
         std::vector<uint16_t> v_16bit;
@@ -570,39 +570,39 @@ void NRE_GLES2_API::setIndexBufferMemoryData(std::size_t id, const std::vector<u
             v_16bit.push_back(x);
         }
 
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, v.size() * sizeof(uint16_t), &v_16bit[0], NRE2GLES2_BufferUse(buf_usage));
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, v.size() * sizeof(uint16_t), &v_16bit[0], nre::gles2::buffer_use(buf_usage));
     }
 }
 
-void NRE_GLES2_API::deleteIndexBuffer(std::size_t id) {
+void nre::gles2::api_t::delete_index_buffer(std::size_t id) {
 
-    this->check_ibo_id_(id, "deleteIndexBuffer");
+    this->check_ibo_id(id, "delete_index_buffer");
 
-    glDeleteBuffers(1, &this->ibos[id].handle);
+    glDeleteBuffers(1, &this->ibos_[id].handle);
     this->vao_ibos_[this->active_vao_] = 0;
-    this->ibos.erase(id);
+    this->ibos_.erase(id);
 }
 
 //----------------------Uniform State ----------------//
 
-void NRE_GLES2_API::setProgramTextureSlot(std::size_t id, std::string name, int slot) {
-    this->check_prog_id_(id, "setProgramTextureSlot");
-    this->check_prog_complete_(id, "setProgramTextureSlot");
-    this->check_prog_uniform_(id, name, "setProgramTextureSlot");
+void nre::gles2::api_t::set_program_texture_slot(std::size_t id, const std::string& name, int slot) {
+    this->check_prog_id(id, "set_program_texture_slot");
+    this->check_prog_complete(id, "set_program_texture_slot");
+    this->check_prog_uniform(id, name, "set_program_texture_slot");
 
-    if (this->active_prog_ != this->progs[id].handle) {
-        glUseProgram(this->progs[id].handle);
-        this->active_prog_ = this->progs[id].handle;
+    if (this->active_prog_ != this->progs_[id].handle) {
+        glUseProgram(this->progs_[id].handle);
+        this->active_prog_ = this->progs_[id].handle;
     }
-    auto uniform_type_enum = this->prog_db[this->progs[id]].uniforms[name].type;
+    auto uniform_type_enum = this->prog_db_[this->progs_[id]].uniforms[name].type;
     if ((uniform_type_enum == GL_SAMPLER_2D) or (uniform_type_enum == GL_SAMPLER_2D_SHADOW)) {
         // This is really stupid. I wasted a week trying to find what appears an intentional change in emscripten
         // apparently glUniform* function only accept glGetUniformLocation as arguments, else it is "undefined"
         // I do not understand why they did this. It just seems slow for me for no reason
 #ifndef OE_PLATFORM_WEB
-        glUniform1i(this->prog_db[this->progs[id]].uniforms[name].slot, slot);
+        glUniform1i(this->prog_db_[this->progs_[id]].uniforms[name].slot, slot);
 #else
-        glUniform1i(glGetUniformLocation(this->progs[id].handle, name.c_str()), slot);
+        glUniform1i(glGetUniformLocation(this->progs_[id].handle, name.c_str()), slot);
 #endif
     }
     else {
@@ -611,24 +611,24 @@ void NRE_GLES2_API::setProgramTextureSlot(std::size_t id, std::string name, int 
     }
 }
 
-void NRE_GLES2_API::setProgramUniformData(std::size_t id, std::string name, uint32_t data) {
-    this->check_prog_id_(id, "setProgramUniformData");
-    this->check_prog_complete_(id, "setProgramUniformData");
-    this->check_prog_uniform_(id, name, "setProgramUniformData");
+void nre::gles2::api_t::set_program_uniform_data(std::size_t id, const std::string& name, uint32_t data) {
+    this->check_prog_id(id, "set_program_uniform_data");
+    this->check_prog_complete(id, "set_program_uniform_data");
+    this->check_prog_uniform(id, name, "set_program_uniform_data");
 
-    if (this->active_prog_ != this->progs[id].handle) {
-        glUseProgram(this->progs[id].handle);
-        this->active_prog_ = this->progs[id].handle;
+    if (this->active_prog_ != this->progs_[id].handle) {
+        glUseProgram(this->progs_[id].handle);
+        this->active_prog_ = this->progs_[id].handle;
     }
-    auto uniform_type_enum = this->prog_db[this->progs[id]].uniforms[name].type;
+    auto uniform_type_enum = this->prog_db_[this->progs_[id]].uniforms[name].type;
     if (uniform_type_enum == GL_INT) {
         // This is really stupid. I wasted a week trying to find what appears an intentional change in emscripten
         // apparently glUniform* function only accept glGetUniformLocation as arguments, else it is "undefined"
         // I do not understand why they did this. It just seems slow for me for no reason
 #ifndef OE_PLATFORM_WEB
-        glUniform1i(this->prog_db[this->progs[id]].uniforms[name].slot, data);
+        glUniform1i(this->prog_db_[this->progs_[id]].uniforms[name].slot, data);
 #else
-        glUniform1i(glGetUniformLocation(this->progs[id].handle, name.c_str()), data);
+        glUniform1i(glGetUniformLocation(this->progs_[id].handle, name.c_str()), data);
 #endif
     }
     else {
@@ -637,24 +637,24 @@ void NRE_GLES2_API::setProgramUniformData(std::size_t id, std::string name, uint
     }
 }
 
-void NRE_GLES2_API::setProgramUniformData(std::size_t id, std::string name, float data) {
-    this->check_prog_id_(id, "setProgramUniformData");
-    this->check_prog_complete_(id, "setProgramUniformData");
-    this->check_prog_uniform_(id, name, "setProgramUniformData");
+void nre::gles2::api_t::set_program_uniform_data(std::size_t id, const std::string& name, float data) {
+    this->check_prog_id(id, "set_program_uniform_data");
+    this->check_prog_complete(id, "set_program_uniform_data");
+    this->check_prog_uniform(id, name, "set_program_uniform_data");
 
-    if (this->active_prog_ != this->progs[id].handle) {
-        glUseProgram(this->progs[id].handle);
-        this->active_prog_ = this->progs[id].handle;
+    if (this->active_prog_ != this->progs_[id].handle) {
+        glUseProgram(this->progs_[id].handle);
+        this->active_prog_ = this->progs_[id].handle;
     }
-    auto uniform_type_enum = this->prog_db[this->progs[id]].uniforms[name].type;
+    auto uniform_type_enum = this->prog_db_[this->progs_[id]].uniforms[name].type;
     if (uniform_type_enum == GL_FLOAT) {
         // This is really stupid. I wasted a week trying to find what appears an intentional change in emscripten
         // apparently glUniform* function only accept glGetUniformLocation as arguments, else it is "undefined"
         // I do not understand why they did this. It just seems slow for me for no reason
 #ifndef OE_PLATFORM_WEB
-        glUniform1f(this->prog_db[this->progs[id]].uniforms[name].slot, data);
+        glUniform1f(this->prog_db_[this->progs_[id]].uniforms[name].slot, data);
 #else
-        glUniform1f(glGetUniformLocation(this->progs[id].handle, name.c_str()), data);
+        glUniform1f(glGetUniformLocation(this->progs_[id].handle, name.c_str()), data);
 #endif
     }
     else {
@@ -663,23 +663,23 @@ void NRE_GLES2_API::setProgramUniformData(std::size_t id, std::string name, floa
     }
 }
 
-void NRE_GLES2_API::setProgramUniformData(std::size_t id, std::string name, const std::vector<float>& data) {
-    this->check_prog_id_(id, "setProgramUniformData");
-    this->check_prog_complete_(id, "setProgramUniformData");
-    this->check_prog_uniform_(id, name, "setProgramUniformData");
-    this->check_prog_uniform_property_(id, name, data.size(), "setProgramUniformData", false);
+void nre::gles2::api_t::set_program_uniform_data(std::size_t id, const std::string& name, const std::vector<float>& data) {
+    this->check_prog_id(id, "set_program_uniform_data");
+    this->check_prog_complete(id, "set_program_uniform_data");
+    this->check_prog_uniform(id, name, "set_program_uniform_data");
+    this->check_prog_uniform_property(id, name, data.size(), "set_program_uniform_data", false);
 
 
-    if (this->active_prog_ != this->progs[id].handle) {
-        glUseProgram(this->progs[id].handle);
-        this->active_prog_ = this->progs[id].handle;
+    if (this->active_prog_ != this->progs_[id].handle) {
+        glUseProgram(this->progs_[id].handle);
+        this->active_prog_ = this->progs_[id].handle;
     }
-    auto uniform_type_enum = this->prog_db[this->progs[id]].uniforms[name].type;
+    auto uniform_type_enum = this->prog_db_[this->progs_[id]].uniforms[name].type;
     // This is really stupid. I wasted a week trying to find what appears an intentional change in emscripten
     // apparently glUniform* function only accept glGetUniformLocation as arguments, else it is "undefined"
     // I do not understand why they did this. It just seems slow for me for no reason
 #ifndef OE_PLATFORM_WEB
-    auto uniform_id = this->prog_db[this->progs[id]].uniforms[name].slot;
+    auto uniform_id = this->prog_db_[this->progs_[id]].uniforms[name].slot;
     if (uniform_type_enum == GL_FLOAT_VEC2) {
         glUniform2f(uniform_id, data[0], data[1]);
     }
@@ -699,73 +699,73 @@ void NRE_GLES2_API::setProgramUniformData(std::size_t id, std::string name, cons
     }
 #else
     if (uniform_type_enum == GL_FLOAT_VEC2) {
-        glUniform2f(glGetUniformLocation(this->progs[id].handle, name.c_str()), data[0], data[1]);
+        glUniform2f(glGetUniformLocation(this->progs_[id].handle, name.c_str()), data[0], data[1]);
     }
     else if (uniform_type_enum == GL_FLOAT_VEC3) {
-        glUniform3f(glGetUniformLocation(this->progs[id].handle, name.c_str()), data[0], data[1], data[2]);
+        glUniform3f(glGetUniformLocation(this->progs_[id].handle, name.c_str()), data[0], data[1], data[2]);
     }
     else if ((uniform_type_enum == GL_FLOAT_VEC4) or (uniform_type_enum == GL_FLOAT_MAT2)) {
-        glUniform4f(glGetUniformLocation(this->progs[id].handle, name.c_str()), data[0], data[1], data[2], data[3]);
+        glUniform4f(glGetUniformLocation(this->progs_[id].handle, name.c_str()), data[0], data[1], data[2], data[3]);
     }
     else if (uniform_type_enum == GL_FLOAT_MAT3) {
-        glUniformMatrix3fv(glGetUniformLocation(this->progs[id].handle, name.c_str()), 1, false, &data[0]);
+        glUniformMatrix3fv(glGetUniformLocation(this->progs_[id].handle, name.c_str()), 1, false, &data[0]);
     }
     else if (uniform_type_enum == GL_FLOAT_MAT4) {
         // cout << "SUCCESS" << id << " " << name <<  endl;
 
-        glUniformMatrix4fv(glGetUniformLocation(this->progs[id].handle, name.c_str()), 1, false, &data[0]);
+        glUniformMatrix4fv(glGetUniformLocation(this->progs_[id].handle, name.c_str()), 1, false, &data[0]);
     }
 #endif
     else {
-        throw nre::gpu::invalid_uniform_property(id, name, data.size(), "setProgramUniformData", true);
+        throw nre::gpu::invalid_uniform_property(id, name, data.size(), "set_program_uniform_data", true);
     }
 }
 
-int NRE_GLES2_API::getProgramUniformSlot(std::size_t id, std::string name) {
-    this->check_prog_id_(id, "getProgramUniformSlot");
-    this->check_prog_complete_(id, "getProgramUniformSlot");
-    if (this->prog_db[this->progs[id]].hasUniform(name)) {
-        return this->prog_db[this->progs[id]].uniforms[name].slot;
+int nre::gles2::api_t::get_program_uniform_slot(std::size_t id, const std::string& name) {
+    this->check_prog_id(id, "get_program_uniform_slot");
+    this->check_prog_complete(id, "get_program_uniform_slot");
+    if (this->prog_db_[this->progs_[id]].has_uniform(name)) {
+        return this->prog_db_[this->progs_[id]].uniforms[name].slot;
     }
     return -2;
 }
 
 //---------------------Vertex Layout-----------------------------//
 
-void NRE_GLES2_API::setVertexLayoutFormat(std::size_t id, std::vector<nre::gpu::vertex_layout_input> inputs) {
+void nre::gles2::api_t::set_vertex_layout_format(std::size_t id, std::vector<nre::gpu::vertex_layout_input> inputs) {
 
-    this->check_vao_id_(id, "setVertexlayoutFormat");
+    this->check_vao_id(id, "setVertexlayout_format");
 
-    this->vaos[id].layout = inputs;
+    this->vaos_[id].layout = inputs;
     for (size_t x = 0; x < inputs.size(); x++) {
-        this->check_vao_vbo_(id, inputs[x].vertex_buffer, "setVertexLayoutFormat");
+        this->check_vao_vbo(id, inputs[x].vertex_buffer, "set_vertex_layout_format");
     }
 }
 
-void NRE_GLES2_API::deleteVertexLayout(std::size_t id) {
-    this->check_vao_id_(id, "deleteVertexLayout");
-    // glDeleteVertexArrays(1, &this->vaos[id].handle);
+void nre::gles2::api_t::delete_vertex_layout(std::size_t id) {
+    this->check_vao_id(id, "delete_vertex_layout");
+    // glDeleteVertexArrays(1, &this->vaos_[id].handle);
     this->active_vao_ = 0;
-    this->vaos.erase(id);
+    this->vaos_.erase(id);
 }
 
 //-----------------------Textures and Framebuffers -------------//
 
-void NRE_GLES2_API::setTextureFormat(std::size_t id, nre::gpu::TEXTURE_TYPE type, nre::gpu::TEXTURE_FILTER filter,
-                                     uint32_t x_in, uint32_t y_in, int mipmap_count) {
-    this->check_texture_id_(id, "setTextureFormat");
+void nre::gles2::api_t::set_texture_format(std::size_t id, nre::gpu::TEXTURE_TYPE type, nre::gpu::TEXTURE_FILTER filter,
+                                           uint32_t x_in, uint32_t y_in, int mipmap_count) {
+    this->check_texture_id(id, "set_texture_format");
 
-    if (this->textures[id].hasNotChanged(type, filter, x_in, y_in, mipmap_count)) return;
+    if (this->textures_[id].has_not_changed(type, filter, x_in, y_in, mipmap_count)) return;
 
-    this->textures[id].type    = type;
-    this->textures[id].filter  = filter;
-    this->textures[id].x       = x_in;
-    this->textures[id].y       = y_in;
-    this->textures[id].mipmaps = mipmap_count;
+    this->textures_[id].type    = type;
+    this->textures_[id].filter  = filter;
+    this->textures_[id].x       = x_in;
+    this->textures_[id].y       = y_in;
+    this->textures_[id].mipmaps = mipmap_count;
 
 
-    glBindTexture(GL_TEXTURE_2D, this->textures[id].handle);
-    glTexImage2D(GL_TEXTURE_2D, 0, teximage_internalformat_(type), x_in, y_in, 0, teximage_format_(type), teximage_type_(type),
+    glBindTexture(GL_TEXTURE_2D, this->textures_[id].handle);
+    glTexImage2D(GL_TEXTURE_2D, 0, teximage_internalformat(type), x_in, y_in, 0, teximage_format(type), teximage_textype(type),
                  0);
     if (mipmap_count == 0 and filter == nre::gpu::LINEAR) {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -789,53 +789,53 @@ void NRE_GLES2_API::setTextureFormat(std::size_t id, nre::gpu::TEXTURE_TYPE type
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::setFrameBufferTexture(std::size_t fbo_id, std::size_t texture_id, int slot) {
-    this->check_fbo_id_(fbo_id, "setFrameBufferTexture");
-    this->check_texture_id_(texture_id, "setFrameBufferTexture");
+void nre::gles2::api_t::set_framebuffer_texture(std::size_t fbo_id, std::size_t texture_id, int slot) {
+    this->check_fbo_id(fbo_id, "set_framebufferTexture");
+    this->check_texture_id(texture_id, "set_framebufferTexture");
     assert((slot >= 0) and (slot < 3));
 
-    this->fbos[fbo_id].texture = texture_id;
+    this->fbos_[fbo_id].texture = texture_id;
 
-    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[fbo_id].handle);
-    glBindTexture(GL_TEXTURE_2D, this->textures[texture_id].handle);
+    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[fbo_id].handle);
+    glBindTexture(GL_TEXTURE_2D, this->textures_[texture_id].handle);
 
-    if (this->textures[texture_id].type != nre::gpu::DEPTHSTENCIL) {
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_TEXTURE_2D, this->textures[texture_id].handle,
+    if (this->textures_[texture_id].type != nre::gpu::DEPTHSTENCIL) {
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + slot, GL_TEXTURE_2D, this->textures_[texture_id].handle,
                                0);
     }
     else {
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, this->textures[texture_id].handle,
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, this->textures_[texture_id].handle,
                                0);
     }
 
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::setTextureSlot(std::size_t id, int slot) {
-    this->check_texture_id_(id, "setTextureSlot");
+void nre::gles2::api_t::set_texture_slot(std::size_t id, int slot) {
+    this->check_texture_id(id, "set_texture_slot");
     glActiveTexture(GL_TEXTURE0 + slot);
-    glBindTexture(GL_TEXTURE_2D, this->textures[id].handle);
+    glBindTexture(GL_TEXTURE_2D, this->textures_[id].handle);
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::deleteTexture(std::size_t id) {
-    this->check_texture_id_(id, "deleteTexture");
-    glDeleteTextures(1, &this->textures[id].handle);
-    this->textures.erase(id);
+void nre::gles2::api_t::delete_texture(std::size_t id) {
+    this->check_texture_id(id, "delete_texture");
+    glDeleteTextures(1, &this->textures_[id].handle);
+    this->textures_.erase(id);
 }
 
-void NRE_GLES2_API::copyFrameBuffer(std::size_t src, std::size_t target, nre::gpu::FRAMEBUFFER_COPY method) {
-    this->check_fbo_id_(src, "copyFrameBuffer");
-    this->check_texture_id_(this->fbos[src].texture, "copyFrameBuffer");
+void nre::gles2::api_t::copy_framebuffer(std::size_t src, std::size_t target, nre::gpu::FRAMEBUFFER_COPY method) {
+    this->check_fbo_id(src, "copy_framebuffer");
+    this->check_texture_id(this->fbos_[src].texture, "copy_framebuffer");
 
-    auto x_tmp = this->textures[this->fbos[src].texture].x;
-    auto y_tmp = this->textures[this->fbos[src].texture].y;
+    auto x_tmp = this->textures_[this->fbos_[src].texture].x;
+    auto y_tmp = this->textures_[this->fbos_[src].texture].y;
 
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, this->fbos[src].handle);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, this->fbos_[src].handle);
     if (target != 0) {
-        this->check_fbo_id_(target, "copyFrameBuffer");
-        this->check_texture_id_(this->fbos[target].texture, "copyFrameBuffer");
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, this->fbos[target].handle);
+        this->check_fbo_id(target, "copy_framebuffer");
+        this->check_texture_id(this->fbos_[target].texture, "copy_framebuffer");
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, this->fbos_[target].handle);
     }
     else {
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
@@ -853,10 +853,10 @@ void NRE_GLES2_API::copyFrameBuffer(std::size_t src, std::size_t target, nre::gp
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::clearFrameBuffer(std::size_t id, nre::gpu::FRAMEBUFFER_COPY clear, float alpha_value) {
-    this->check_fbo_id_(id, "clearFrameBuffer");
+void nre::gles2::api_t::clear_framebuffer(std::size_t id, nre::gpu::FRAMEBUFFER_COPY clear, float alpha_value) {
+    this->check_fbo_id(id, "clear_framebuffer");
 
-    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[id].handle);
+    glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[id].handle);
     glDepthMask(GL_TRUE);
     glColorMask(1, 1, 1, 1);
     glClearColor(0.0f, 0.0f, 0.0f, alpha_value);
@@ -879,10 +879,10 @@ void NRE_GLES2_API::clearFrameBuffer(std::size_t id, nre::gpu::FRAMEBUFFER_COPY 
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::useFrameBuffer(std::size_t id) {
+void nre::gles2::api_t::use_framebuffer(std::size_t id) {
     if (id != 0) {
-        this->check_fbo_id_(id, "useFrameBuffer");
-        glBindFramebuffer(GL_FRAMEBUFFER, this->fbos[id].handle);
+        this->check_fbo_id(id, "use_framebuffer");
+        glBindFramebuffer(GL_FRAMEBUFFER, this->fbos_[id].handle);
     }
     else {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -891,42 +891,42 @@ void NRE_GLES2_API::useFrameBuffer(std::size_t id) {
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::deleteFrameBuffer(std::size_t id) {
-    this->check_fbo_id_(id, "deleteFrameBuffer");
-    glDeleteFramebuffers(1, &this->fbos[id].handle);
-    this->fbos.erase(id);
+void nre::gles2::api_t::delete_framebuffer(std::size_t id) {
+    this->check_fbo_id(id, "delete_framebuffer");
+    glDeleteFramebuffers(1, &this->fbos_[id].handle);
+    this->fbos_.erase(id);
 }
 
 //---------------------Shader Programs-----------------------------//
 
-void NRE_GLES2_API::setProgramVS(std::size_t id, nre::gpu::vertex_shader_t vs) {
-    this->check_prog_id_(id, "setProgramVS");
+void nre::gles2::api_t::set_program_vs(std::size_t id, nre::gpu::vertex_shader_t vs) {
+    this->check_prog_id(id, "set_program_vs");
 
-    this->progs[id].vs_setup = false;
-    this->progs[id].setup    = false;
-    this->progs[id].vs       = vs;
+    this->progs_[id].vs_setup = false;
+    this->progs_[id].setup    = false;
+    this->progs_[id].vs       = vs;
 }
-void NRE_GLES2_API::setProgramFS(std::size_t id, nre::gpu::pixel_shader_t fs) {
-    this->check_prog_id_(id, "setProgramFS");
+void nre::gles2::api_t::set_program_fs(std::size_t id, nre::gpu::pixel_shader_t fs) {
+    this->check_prog_id(id, "set_program_fs");
 
-    this->progs[id].fs_setup = false;
-    this->progs[id].setup    = false;
-    this->progs[id].fs       = fs;
+    this->progs_[id].fs_setup = false;
+    this->progs_[id].setup    = false;
+    this->progs_[id].fs       = fs;
 }
 
-void NRE_GLES2_API::setProgramVS(std::size_t id, std::string data) {
+void nre::gles2::api_t::set_program_vs(std::size_t id, std::string data) {
 
     data = data + "";
-    this->check_prog_id_(id, "setProgramVS - internal");
+    this->check_prog_id(id, "set_program_vs - internal");
     GLuint shader_id;
-    if (!this->progs[id].vs_setup)
+    if (!this->progs_[id].vs_setup)
         shader_id = glCreateShader(GL_VERTEX_SHADER);
     else
-        shader_id = this->progs[id].vs_handle;
+        shader_id = this->progs_[id].vs_handle;
 
-    this->progs[id].vs_setup  = true;
-    this->progs[id].vs_handle = shader_id;
-    this->progs[id].setup     = false;
+    this->progs_[id].vs_setup  = true;
+    this->progs_[id].vs_handle = shader_id;
+    this->progs_[id].setup     = false;
 
     /// compile and attach shader
     const char* c_str = data.c_str();
@@ -946,26 +946,26 @@ void NRE_GLES2_API::setProgramVS(std::size_t id, std::string data) {
         glGetShaderInfoLog(shader_id, max_length, &actual_length, log);
 
         stringstream ss;
-        ss << "[NRE GL Shader Warning] in vertex shader: " << this->progs[id].vs.info() << endl << log << endl;
+        ss << "[NRE GL Shader Warning] in vertex shader: " << this->progs_[id].vs.info() << endl << log << endl;
         cout << ss.str();
         OE_WriteToLog(ss.str());
     }
 }
 
-// void setProgramGS(std::size_t, FE_GPU_Shader){}
-void NRE_GLES2_API::setProgramFS(std::size_t id, std::string data) {
+// void set_programGS(std::size_t, FE_GPU_Shader){}
+void nre::gles2::api_t::set_program_fs(std::size_t id, std::string data) {
 
     data = data + "";
-    this->check_prog_id_(id, "setProgramFS - internal");
+    this->check_prog_id(id, "set_program_fs - internal");
     GLuint shader_id;
-    if (!this->progs[id].fs_setup)
+    if (!this->progs_[id].fs_setup)
         shader_id = glCreateShader(GL_FRAGMENT_SHADER);
     else
-        shader_id = this->progs[id].fs_handle;
+        shader_id = this->progs_[id].fs_handle;
 
-    this->progs[id].fs_setup  = true;
-    this->progs[id].fs_handle = shader_id;
-    this->progs[id].setup     = false;
+    this->progs_[id].fs_setup  = true;
+    this->progs_[id].fs_handle = shader_id;
+    this->progs_[id].setup     = false;
 
     /// compile and attach shader
     const char* c_str     = data.c_str();
@@ -984,156 +984,156 @@ void NRE_GLES2_API::setProgramFS(std::size_t id, std::string data) {
         glGetShaderInfoLog(shader_id, max_length, &actual_length, log);
 
         stringstream ss;
-        ss << "[NRE GL Shader Warning] in pixel shader: " << this->progs[id].fs.info() << endl << log << endl;
+        ss << "[NRE GL Shader Warning] in pixel shader: " << this->progs_[id].fs.info() << endl << log << endl;
         cout << ss.str();
         OE_WriteToLog(ss.str());
     }
 }
 
-// void setProgramTCS(std::size_t, FE_GPU_Shader){}
-// void setProgramTES(std::size_t, FE_GPU_Shader){}
+// void set_programTCS(std::size_t, FE_GPU_Shader){}
+// void set_programTES(std::size_t, FE_GPU_Shader){}
 
-void NRE_GLES2_API::setupProgram(std::size_t id) {
+void nre::gles2::api_t::setup_program(std::size_t id) {
 
-    this->check_prog_id_(id, "setupProgram");
+    this->check_prog_id(id, "setup_program");
 
     // ignore if the program is already setup
-    if (this->progs[id].setup) return;
+    if (this->progs_[id].setup) return;
 
     // setup vertex shader
-    if (!this->progs[id].vs_setup) {
-        if (this->vs_db.count(this->progs[id].vs) == 0) {
+    if (!this->progs_[id].vs_setup) {
+        if (this->vs_db_.count(this->progs_[id].vs) == 0) {
 
             // vertex shader does not exist, make a new entry
-            this->setProgramVS(id, this->progs[id].vs.gen_shader());
-            this->vs_db[this->progs[id].vs] = this->progs[id].vs_handle;
+            this->set_program_vs(id, this->progs_[id].vs.gen_shader());
+            this->vs_db_[this->progs_[id].vs] = this->progs_[id].vs_handle;
         }
         else {
 
             // vertex shader already exists, reuse that
-            this->progs[id].vs_handle = this->vs_db[this->progs[id].vs];
-            this->progs[id].vs_setup  = true;
+            this->progs_[id].vs_handle = this->vs_db_[this->progs_[id].vs];
+            this->progs_[id].vs_setup  = true;
         }
     }
 
     // setup pixel (fragment) shader
-    if (!this->progs[id].fs_setup) {
-        if (this->fs_db.count(this->progs[id].fs) == 0) {
+    if (!this->progs_[id].fs_setup) {
+        if (this->fs_db_.count(this->progs_[id].fs) == 0) {
 
             // pixel (fragment) shader does not exist, make a new entry
-            this->setProgramFS(id, this->progs[id].fs.gen_shader());
+            this->set_program_fs(id, this->progs_[id].fs.gen_shader());
 
-            this->fs_db[this->progs[id].fs] = this->progs[id].fs_handle;
-            this->progs[id].fs_setup        = true;
+            this->fs_db_[this->progs_[id].fs] = this->progs_[id].fs_handle;
+            this->progs_[id].fs_setup         = true;
         }
         else {
 
             // pixel (fragment) shader already exists, reuse that
-            this->progs[id].fs_handle = this->fs_db[this->progs[id].fs];
-            this->progs[id].fs_setup  = true;
+            this->progs_[id].fs_handle = this->fs_db_[this->progs_[id].fs];
+            this->progs_[id].fs_setup  = true;
         }
     }
 
     // check if program already exists
-    if (this->prog_db.count(this->progs[id]) > 0) {
+    if (this->prog_db_.count(this->progs_[id]) > 0) {
 
-        this->progs[id].handle = this->prog_db[this->progs[id]].handle;
-        this->progs[id].setup  = true;
+        this->progs_[id].handle = this->prog_db_[this->progs_[id]].handle;
+        this->progs_[id].setup  = true;
 
         return;
     }
     else {
-        this->progs[id].handle = glCreateProgram();
-        // this->prog_db[this->progs[id]] = this->progs[id].handle;
-        this->prog_db[this->progs[id]]        = NRE_GLES2_ProgramData();
-        this->prog_db[this->progs[id]].handle = this->progs[id].handle;
+        this->progs_[id].handle = glCreateProgram();
+        // this->prog_db_[this->progs_[id]] = this->progs_[id].handle;
+        this->prog_db_[this->progs_[id]]        = nre::gles2::program_data_t();
+        this->prog_db_[this->progs_[id]].handle = this->progs_[id].handle;
     }
 
     // make sure that the vertex and fragment shaders actually compile
     // in case the program does not already exist
-    assert(this->progs[id].vs_setup && this->progs[id].fs_setup);
+    assert(this->progs_[id].vs_setup && this->progs_[id].fs_setup);
 
-    glAttachShader(this->progs[id].handle, this->progs[id].vs_handle);
-    glAttachShader(this->progs[id].handle, this->progs[id].fs_handle);
+    glAttachShader(this->progs_[id].handle, this->progs_[id].vs_handle);
+    glAttachShader(this->progs_[id].handle, this->progs_[id].fs_handle);
 
-    glBindAttribLocation(this->progs[id].handle, 0, "oe_position");
+    glBindAttribLocation(this->progs_[id].handle, 0, "oe_position");
 
-    if (not(this->progs[id].vs.fullscreenQuad or (this->progs[id].vs.type == nre::gpu::VS_Z_PREPASS))) {
-        glBindAttribLocation(this->progs[id].handle, 1, "oe_normals");
-        for (size_t i = 0; i < this->progs[id].vs.num_of_uvs; i++) {
+    if (not(this->progs_[id].vs.fullscreenQuad or (this->progs_[id].vs.type == nre::gpu::VS_Z_PREPASS))) {
+        glBindAttribLocation(this->progs_[id].handle, 1, "oe_normals");
+        for (size_t i = 0; i < this->progs_[id].vs.num_of_uvs; i++) {
             std::string attrib_name = "oe_uvs" + to_string(i);
-            glBindAttribLocation(this->progs[id].handle, i + 2, attrib_name.c_str());
+            glBindAttribLocation(this->progs_[id].handle, i + 2, attrib_name.c_str());
         }
     }
 
 
-    glLinkProgram(this->progs[id].handle);
+    glLinkProgram(this->progs_[id].handle);
 
 
     /// IMPORTANT: check if program is linked correctly
     int parameters = -1;
-    glGetProgramiv(this->progs[id].handle, GL_LINK_STATUS, &parameters);
+    glGetProgramiv(this->progs_[id].handle, GL_LINK_STATUS, &parameters);
     if (GL_TRUE != parameters) {
 
         int  max_length    = 2048;
         int  actual_length = 0;
         char log[2048];
-        glGetProgramInfoLog(this->progs[id].handle, max_length, &actual_length, log);
+        glGetProgramInfoLog(this->progs_[id].handle, max_length, &actual_length, log);
         cout << log << endl;
         OE_WriteToLog(log);
     }
 
     /// IMPORTANT: make sure program is runnable
-    glValidateProgram(this->progs[id].handle);
+    glValidateProgram(this->progs_[id].handle);
     parameters = -1;
-    glGetProgramiv(this->progs[id].handle, GL_VALIDATE_STATUS, &parameters);
+    glGetProgramiv(this->progs_[id].handle, GL_VALIDATE_STATUS, &parameters);
     if (GL_TRUE != parameters) {
 
         int  max_length    = 2048;
         int  actual_length = 0;
         char log[2048];
-        glGetProgramInfoLog(this->progs[id].handle, max_length, &actual_length, log);
+        glGetProgramInfoLog(this->progs_[id].handle, max_length, &actual_length, log);
 
         stringstream ss;
-        ss << "[NRE GL Shader Linking Warning] with shaders: " << this->progs[id].vs.info() << " " << this->progs[id].fs.info()
-           << endl
+        ss << "[NRE GL Shader Linking Warning] with shaders: " << this->progs_[id].vs.info() << " "
+           << this->progs_[id].fs.info() << endl
            << log << endl;
         cout << ss.str();
         OE_WriteToLog(ss.str());
     }
-    glUseProgram(this->progs[id].handle);
-    this->active_prog_ = this->progs[id].handle;
+    glUseProgram(this->progs_[id].handle);
+    this->active_prog_ = this->progs_[id].handle;
 
     /// get all active uniform blocks
-    this->get_program_all_uniforms_(id);
+    this->get_program_all_uniforms(id);
 
-    this->progs[id].setup = true;
+    this->progs_[id].setup = true;
 
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::deleteProgram(std::size_t id) {
+void nre::gles2::api_t::delete_program(std::size_t id) {
 
-    this->check_prog_id_(id, "deleteProgram");
+    this->check_prog_id(id, "delete_program");
 
     this->active_prog_ = 0;
-    this->progs.erase(id);
+    this->progs_.erase(id);
 }
 
 //---------------------Draw calls-----------------------------//
 
-void NRE_GLES2_API::draw(nre::gpu::draw_call dc_info) {
+void nre::gles2::api_t::draw(nre::gpu::draw_call dc_info) {
 
-    this->check_prog_id_(dc_info.program, "draw");
-    this->check_vao_id_(dc_info.vertex_layout, "draw");
+    this->check_prog_id(dc_info.program, "draw");
+    this->check_vao_id(dc_info.vertex_layout, "draw");
 
     bool is_ranged_rendering = (dc_info.offset != 0) or (dc_info.amount != 0);
 
     // program
-    this->setupProgram(dc_info.program);
-    if (this->active_prog_ != this->progs[dc_info.program].handle) {
-        glUseProgram(this->progs[dc_info.program].handle);
-        this->active_prog_ = this->progs[dc_info.program].handle;
+    this->setup_program(dc_info.program);
+    if (this->active_prog_ != this->progs_[dc_info.program].handle) {
+        glUseProgram(this->progs_[dc_info.program].handle);
+        this->active_prog_ = this->progs_[dc_info.program].handle;
     }
 
     // vao
@@ -1141,25 +1141,25 @@ void NRE_GLES2_API::draw(nre::gpu::draw_call dc_info) {
     if (this->active_vao_ != vao_id) {
 
         // disable unused vertex attributes if enabled before
-        if (this->enabled_vao_attribs > this->vaos[vao_id].layout.size()) {
-            for (std::size_t i = this->enabled_vao_attribs; i > this->vaos[vao_id].layout.size(); i--) {
+        if (this->enabled_vao_attribs_ > this->vaos_[vao_id].layout.size()) {
+            for (std::size_t i = this->enabled_vao_attribs_; i > this->vaos_[vao_id].layout.size(); i--) {
                 glDisableVertexAttribArray(i);
             }
         }
 
-        for (size_t x = 0; x < this->vaos[vao_id].layout.size(); x++) {
+        for (size_t x = 0; x < this->vaos_[vao_id].layout.size(); x++) {
 
-            this->check_vao_vbo_(vao_id, this->vaos[vao_id].layout[x].vertex_buffer, "draw");
+            this->check_vao_vbo(vao_id, this->vaos_[vao_id].layout[x].vertex_buffer, "draw");
 
-            glBindBuffer(GL_ARRAY_BUFFER, this->vbos[this->vaos[vao_id].layout[x].vertex_buffer].handle);
+            glBindBuffer(GL_ARRAY_BUFFER, this->vbos_[this->vaos_[vao_id].layout[x].vertex_buffer].handle);
             glVertexAttribPointer(
-                x, this->vaos[vao_id].layout[x].amount, GL_FLOAT, GL_FALSE,
-                sizeof(GLfloat) * this->vaos[vao_id].layout[x].stride,
-                NRE_GLES2_VERTEXL_LAYOUT_OFFSET(sizeof(GLfloat) * static_cast<GLuint>(this->vaos[vao_id].layout[x].offset)));
+                x, this->vaos_[vao_id].layout[x].amount, GL_FLOAT, GL_FALSE,
+                sizeof(GLfloat) * this->vaos_[vao_id].layout[x].stride,
+                NRE_GLES2_VERTEXL_LAYOUT_OFFSET(sizeof(GLfloat) * static_cast<GLuint>(this->vaos_[vao_id].layout[x].offset)));
             glEnableVertexAttribArray(x);
         }
-        this->enabled_vao_attribs = this->vaos[vao_id].layout.size();
-        this->active_vbo_         = 0;
+        this->enabled_vao_attribs_ = this->vaos_[vao_id].layout.size();
+        this->active_vbo_          = 0;
 
         this->active_vao_ = vao_id;
     }
@@ -1167,23 +1167,23 @@ void NRE_GLES2_API::draw(nre::gpu::draw_call dc_info) {
     // optional elements handling
     if (dc_info.index_buf != 0) {
 
-        this->check_ibo_id_(dc_info.index_buf, "draw (indexed)");
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos[dc_info.index_buf].handle);
+        this->check_ibo_id(dc_info.index_buf, "draw (indexed)");
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ibos_[dc_info.index_buf].handle);
 
         if (is_ranged_rendering) {
-            this->check_ibo_offset_length_(dc_info.index_buf, dc_info.offset + dc_info.amount, "draw (indexed)");
-            if (this->ibos[dc_info.index_buf].type_ == GL_UNSIGNED_INT and has_oes_element_index_uint)
+            this->check_ibo_offset_length(dc_info.index_buf, dc_info.offset + dc_info.amount, "draw (indexed)");
+            if (this->ibos_[dc_info.index_buf].type_ == GL_UNSIGNED_INT and has_oes_element_index_uint_)
                 glDrawElements(GL_TRIANGLES, dc_info.amount, GL_UNSIGNED_INT,
                                (GLvoid*)((sizeof(uint32_t)) * 3 * dc_info.offset));
-            else if (not has_oes_element_index_uint)
+            else if (not has_oes_element_index_uint_)
                 cout << "NRE WARNING: Draw call hidden due to too many vertices (no 32-bit index support)" << endl;
             else
                 glDrawElements(GL_TRIANGLES, dc_info.amount, GL_UNSIGNED_SHORT,
                                (GLvoid*)((sizeof(uint16_t)) * 3 * dc_info.offset));
         }
         else {
-            if ((this->ibos[dc_info.index_buf].type_ == GL_UNSIGNED_SHORT) or has_oes_element_index_uint)
-                glDrawElements(GL_TRIANGLES, this->ibos[dc_info.index_buf].size, this->ibos[dc_info.index_buf].type_,
+            if ((this->ibos_[dc_info.index_buf].type_ == GL_UNSIGNED_SHORT) or has_oes_element_index_uint_)
+                glDrawElements(GL_TRIANGLES, this->ibos_[dc_info.index_buf].size, this->ibos_[dc_info.index_buf].type_,
                                (GLvoid*)NULL);
             else
                 cout << "NRE WARNING: Draw call hidden due to too many vertices (no 32-bit index support)" << endl;
@@ -1191,17 +1191,17 @@ void NRE_GLES2_API::draw(nre::gpu::draw_call dc_info) {
     }
     else {
         if (is_ranged_rendering) {
-            this->check_draw_range_(vao_id, this->getVAOSize(vao_id), dc_info.offset, dc_info.amount, "draw");
+            this->check_draw_range(vao_id, this->get_vao_size(vao_id), dc_info.offset, dc_info.amount, "draw");
             glDrawArrays(GL_TRIANGLES, dc_info.offset, dc_info.amount);
         }
         else {
-            glDrawArrays(GL_TRIANGLES, 0, this->getVAOSize(vao_id));
+            glDrawArrays(GL_TRIANGLES, 0, this->get_vao_size(vao_id));
         }
     }
     if (glGetError() > 0) cout << "GL Error: " << glGetError() << endl;
 }
 
-void NRE_GLES2_API::setRenderMode(nre::gpu::RENDERMODE rendermode) {
+void nre::gles2::api_t::set_render_mode(nre::gpu::RENDERMODE rendermode) {
 
     if (rendermode == nre::gpu::Z_PREPASS_BACKFACE) {
         glDisable(GL_BLEND);
@@ -1375,6 +1375,6 @@ void NRE_GLES2_API::setRenderMode(nre::gpu::RENDERMODE rendermode) {
     }
 }
 
-void NRE_GLES2_API::use_wireframe(bool value_in) {
+void nre::gles2::api_t::use_wireframe(bool value_in) {
     // TODO: Warning
 }

--- a/src/Renderer/GLES2/api_gles2.cpp
+++ b/src/Renderer/GLES2/api_gles2.cpp
@@ -116,7 +116,7 @@ void NRE_GLES2_API::update(uint32_t x_in, uint32_t y_in) {
         nre::gpu::x = x_in;
         nre::gpu::y = y_in;
     }
-    cout << this->prog_db.size() << " " << this->vs_db.size() << " " << this->fs_db.size() << endl;
+    // cout << this->prog_db.size() << " " << this->vs_db.size() << " " << this->fs_db.size() << endl;
     glDepthMask(GL_TRUE);
     glStencilMask(0xFF);
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);

--- a/src/Renderer/GLES2/api_gles2.cpp
+++ b/src/Renderer/GLES2/api_gles2.cpp
@@ -111,10 +111,10 @@ void NRE_GLES2_API::update(uint32_t x_in, uint32_t y_in) {
 
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    if (x_in != nre::gpu::x or y_in != nre::gpu::y) {
+    if (x_in != x_ or y_in != y_) {
         glViewport(0, 0, x_in, y_in);
-        nre::gpu::x = x_in;
-        nre::gpu::y = y_in;
+        x_ = x_in;
+        y_ = y_in;
     }
     // cout << this->prog_db.size() << " " << this->vs_db.size() << " " << this->fs_db.size() << endl;
     glDepthMask(GL_TRUE);
@@ -1371,4 +1371,8 @@ void NRE_GLES2_API::setRenderMode(nre::gpu::RENDERMODE rendermode) {
     else {
         // TODO
     }
+}
+
+void NRE_GLES2_API::use_wireframe(bool value_in) {
+    // TODO: Warning
 }

--- a/src/Renderer/GLES2/api_gles2.cpp
+++ b/src/Renderer/GLES2/api_gles2.cpp
@@ -59,6 +59,8 @@ std::size_t NRE_GLES2_API::getVAOSize(std::size_t id) {
 
 NRE_GLES2_API::NRE_GLES2_API(nre::gpu::info_struct& backend_info) {
     this->vao_ibos_[0] = 0;
+    major_             = backend_info.major;
+    minor_             = backend_info.minor;
 
     // TODO: assume no extensions by default
     backend_info.has_indexed_ranged_draws = true;
@@ -897,14 +899,14 @@ void NRE_GLES2_API::deleteFrameBuffer(std::size_t id) {
 
 //---------------------Shader Programs-----------------------------//
 
-void NRE_GLES2_API::setProgramVS(std::size_t id, nre::gpu::vertex_shader vs) {
+void NRE_GLES2_API::setProgramVS(std::size_t id, nre::gpu::vertex_shader_t vs) {
     this->check_prog_id_(id, "setProgramVS");
 
     this->progs[id].vs_setup = false;
     this->progs[id].setup    = false;
     this->progs[id].vs       = vs;
 }
-void NRE_GLES2_API::setProgramFS(std::size_t id, nre::gpu::pixel_shader fs) {
+void NRE_GLES2_API::setProgramFS(std::size_t id, nre::gpu::pixel_shader_t fs) {
     this->check_prog_id_(id, "setProgramFS");
 
     this->progs[id].fs_setup = false;

--- a/src/Renderer/GLES2/shaders_gles2.cpp
+++ b/src/Renderer/GLES2/shaders_gles2.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-std::string NRE_GenGLES2VertexShader(nre::gpu::vertex_shader vs) {
+std::string nre::gles2::gen_vertex_shader(nre::gpu::vertex_shader_t vs) {
 
     std::string output = "\n";
 
@@ -156,10 +156,10 @@ std::string NRE_GenGLES2VertexShader(nre::gpu::vertex_shader vs) {
         }
     }
 
-    return nre::gpu::shader_base::shader_prefix + output;
+    return nre::gpu::gen_shader_prefix() + output;
 }
 
-std::string NRE_GenGLES2PixelShader(nre::gpu::pixel_shader fs) {
+std::string nre::gles2::gen_pixel_shader(nre::gpu::pixel_shader_t fs) {
 
     std::string output = "\n";
 
@@ -169,7 +169,7 @@ std::string NRE_GenGLES2PixelShader(nre::gpu::pixel_shader fs) {
         output.append(NRE_Shader(varying vec2 position;
 
                                  void main() { gl_FragColor = vec4(vec3(0.5), 1.0); }));
-        return nre::gpu::shader_base::shader_prefix + output;
+        return nre::gpu::gen_shader_prefix() + output;
     }
     else if (fs.type == nre::gpu::FS_GAMMA) {
         output.append(NRE_Shader(varying vec2 position;
@@ -188,7 +188,7 @@ std::string NRE_GenGLES2PixelShader(nre::gpu::pixel_shader fs) {
                                      // }
                                      gl_FragColor = vec4(pow(sampled_data.xyz, vec3(1.0 / 2.2)), sampled_data.w);
                                  }));
-        return nre::gpu::shader_base::shader_prefix + output;
+        return nre::gpu::gen_shader_prefix() + output;
     }
     else {
     }
@@ -249,5 +249,5 @@ std::string NRE_GenGLES2PixelShader(nre::gpu::pixel_shader fs) {
             void main() { gl_FragColor = vec4(abs(normals), 1.0); }));
     }
 
-    return nre::gpu::shader_base::shader_prefix + output;
+    return nre::gpu::gen_shader_prefix() + output;
 }

--- a/src/Renderer/api_gpu.cpp
+++ b/src/Renderer/api_gpu.cpp
@@ -33,8 +33,9 @@ std::string nre::gpu::get_underlying_api_name() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->getRenderingAPI();
-
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->get_rendering_api();
+    case GLES2:
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->get_rendering_api();
     default:
         return "undefined";
     }
@@ -49,9 +50,9 @@ std::size_t nre::gpu::new_vertex_buf() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newVertexBuffer();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_vertex_buffer();
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->newVertexBuffer();
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->new_vertex_buffer();
     default:
         return 0;
     }
@@ -61,9 +62,9 @@ std::size_t nre::gpu::new_program() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newProgram();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_program();
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->newProgram();
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->new_program();
 
     default:
         return 0;
@@ -74,9 +75,9 @@ std::size_t nre::gpu::new_vertex_layout() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newVertexLayout();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_vertex_layout();
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->newVertexLayout();
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->new_vertex_layout();
     default:
         return 0;
     }
@@ -86,9 +87,9 @@ std::size_t nre::gpu::new_index_buf() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newIndexBuffer();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_index_buffer();
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->newIndexBuffer();
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->new_index_buffer();
 
     default:
         return 0;
@@ -99,7 +100,7 @@ std::size_t nre::gpu::new_uniform_buf() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newUniformBuffer();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_uniform_buffer();
     case GLES2:
         throw nre::gpu::unimplemented_function("new_uniform_buf", "OpenGL ES 2", "Uniform buffers are not supported on ES 2.");
     default:
@@ -111,9 +112,9 @@ std::size_t nre::gpu::new_framebuffer() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newFrameBuffer();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_framebuffer();
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->newFrameBuffer();
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->new_framebuffer();
 
     default:
         return 0;
@@ -124,9 +125,9 @@ std::size_t nre::gpu::new_texture() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newTexture();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_texture();
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->newTexture();
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->new_texture();
     default:
         return 0;
     }
@@ -136,9 +137,9 @@ std::size_t nre::gpu::new_renderbuffer() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->newRenderBuffer();
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->new_renderbuffer();
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->newRenderBuffer();
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->new_renderbuffer();
 
     default:
         return 0;
@@ -163,10 +164,10 @@ bool nre::gpu::init(SHADER_BACKEND backend_in, int major, int minor) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        nre::gpu::api = static_cast<void*>(new NRE_GL3_API(nre::gpu::backend_info));
+        nre::gpu::api = static_cast<void*>(new nre::gl3::api_t(nre::gpu::backend_info));
         break;
     case GLES2:
-        nre::gpu::api = static_cast<void*>(new NRE_GLES2_API(nre::gpu::backend_info));
+        nre::gpu::api = static_cast<void*>(new nre::gles2::api_t(nre::gpu::backend_info));
         break;
     default:
         return false;
@@ -181,10 +182,10 @@ void nre::gpu::update(uint32_t x, uint32_t y) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->update(x, y);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->update(x, y);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->update(x, y);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->update(x, y);
         break;
     default:
         return;
@@ -195,13 +196,13 @@ void nre::gpu::destroy() {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->destroy();
-        delete static_cast<NRE_GL3_API*>(nre::gpu::api);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->destroy();
+        delete static_cast<nre::gl3::api_t*>(nre::gpu::api);
         nre::gpu::api = nullptr;
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->destroy();
-        delete static_cast<NRE_GLES2_API*>(nre::gpu::api);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->destroy();
+        delete static_cast<nre::gles2::api_t*>(nre::gpu::api);
         nre::gpu::api = nullptr;
         break;
     default:
@@ -210,14 +211,14 @@ void nre::gpu::destroy() {
 }
 
 // renderbuffers
-void nre::gpu::set_renderbuffer_mode(std::size_t id, nre::gpu::TEXTURE_TYPE a_type, int x, int y) {
+void nre::gpu::set_renderbuffer_textype(std::size_t id, nre::gpu::TEXTURE_TYPE a_type, int x, int y) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setRenderBufferType(id, a_type, x, y);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_renderbuffer_textype(id, a_type, x, y);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setRenderBufferType(id, a_type, x, y);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_renderbuffer_textype(id, a_type, x, y);
         break;
     default:
         return;
@@ -228,10 +229,10 @@ void nre::gpu::set_framebuffer_renderbuffer(std::size_t fbo_id, std::size_t rbo_
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setFrameBufferRenderBuffer(fbo_id, rbo_id, slot);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_framebuffer_renderbuffer(fbo_id, rbo_id, slot);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setFrameBufferRenderBuffer(fbo_id, rbo_id, slot);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_framebuffer_renderbuffer(fbo_id, rbo_id, slot);
         break;
     default:
         return;
@@ -243,10 +244,10 @@ void nre::gpu::set_vertex_buf_memory(std::size_t id, std::size_t memory_size, nr
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setVertexBufferMemory(id, memory_size, buf_usage);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_vertex_buffer_memory(id, memory_size, buf_usage);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setVertexBufferMemory(id, memory_size, buf_usage);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_vertex_buffer_memory(id, memory_size, buf_usage);
         break;
     default:
         return;
@@ -257,10 +258,10 @@ void nre::gpu::set_vertex_buf_data(std::size_t id, const std::vector<float>& dat
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setVertexBufferData(id, data, offset);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_vertex_buffer_data(id, data, offset);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setVertexBufferData(id, data, offset);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_vertex_buffer_data(id, data, offset);
         break;
     default:
         return;
@@ -271,10 +272,10 @@ void nre::gpu::set_vertex_buf_memory_and_data(std::size_t id, const std::vector<
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setVertexBufferMemoryData(id, data, buf_usage);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_vertex_buffer_memory_data(id, data, buf_usage);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setVertexBufferMemoryData(id, data, buf_usage);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_vertex_buffer_memory_data(id, data, buf_usage);
         break;
     default:
         return;
@@ -285,10 +286,10 @@ void nre::gpu::del_vertex_buf(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteVertexBuffer(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_vertex_buffer(id);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->deleteVertexBuffer(id);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->delete_vertex_buffer(id);
         break;
     default:
         return;
@@ -300,10 +301,10 @@ void nre::gpu::set_index_buf_memory(std::size_t id, std::size_t memory_size, nre
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setIndexBufferMemory(id, memory_size, buf_usage);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_index_buffer_memory(id, memory_size, buf_usage);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setIndexBufferMemory(id, memory_size, buf_usage);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_index_buffer_memory(id, memory_size, buf_usage);
         break;
     default:
         return;
@@ -314,10 +315,10 @@ void nre::gpu::set_index_buf_data(std::size_t id, const std::vector<uint32_t>& d
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setIndexBufferData(id, data, offset);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_index_buffer_data(id, data, offset);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setIndexBufferData(id, data, offset);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_index_buffer_data(id, data, offset);
         break;
     default:
         return;
@@ -328,10 +329,10 @@ void nre::gpu::set_index_buf_memory_and_data(std::size_t id, const std::vector<u
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setIndexBufferMemoryData(id, data, buf_usage);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_index_buffer_memory_data(id, data, buf_usage);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setIndexBufferMemoryData(id, data, buf_usage);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_index_buffer_memory_data(id, data, buf_usage);
         break;
     default:
         return;
@@ -342,10 +343,10 @@ void nre::gpu::del_index_buf(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteIndexBuffer(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_index_buffer(id);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->deleteIndexBuffer(id);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->delete_index_buffer(id);
         break;
     default:
         return;
@@ -357,7 +358,7 @@ void nre::gpu::set_uniform_buf_memory(std::size_t id, std::size_t memory_size, n
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBufferMemory(id, memory_size, buf_usage);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_buffer_memory(id, memory_size, buf_usage);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_uniform_buf_memory", "OpenGL ES 2",
@@ -371,7 +372,7 @@ void nre::gpu::set_uniform_buf_data(std::size_t id, const std::vector<float>& da
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBufferData(id, data, offset);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_buffer_data(id, data, offset);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_uniform_buf_data", "OpenGL ES 2",
@@ -385,7 +386,7 @@ void nre::gpu::set_uniform_buf_data(std::size_t id, const std::vector<uint32_t>&
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBufferData(id, data, offset);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_buffer_data(id, data, offset);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_uniform_buf_data", "OpenGL ES 2",
@@ -399,8 +400,8 @@ void nre::gpu::set_uniform_buf_memory_and_data(std::size_t id, const std::vector
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBufferMemory(id, data.size(), buf_usage);
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBufferData(id, data, 0);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_buffer_memory(id, data.size(), buf_usage);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_buffer_data(id, data, 0);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_uniform_buf_memory_and_data", "OpenGL ES 2",
@@ -414,8 +415,8 @@ void nre::gpu::set_uniform_buf_memory_and_data(std::size_t id, const std::vector
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBufferMemory(id, data.size(), buf_usage);
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBufferData(id, data, 0);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_buffer_memory(id, data.size(), buf_usage);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_buffer_data(id, data, 0);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_uniform_buf_memory_and_data", "OpenGL ES 2",
@@ -429,7 +430,7 @@ void nre::gpu::del_uniform_buf(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteUniformBuffer(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_uniform_buffer(id);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("del_uniform_buf", "OpenGL ES 2", "Uniform buffers are not supported on ES 2.");
@@ -442,7 +443,7 @@ void nre::gpu::set_uniform_buf_state(std::size_t id, std::size_t program, int sl
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setUniformBlockState(id, program, slot, offset, length);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_uniform_block_state(id, program, slot, offset, length);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_uniform_buf_state", "OpenGL ES 2",
@@ -452,11 +453,11 @@ void nre::gpu::set_uniform_buf_state(std::size_t id, std::size_t program, int sl
     }
 }
 // program uniform buffer/texture state
-void nre::gpu::set_program_uniform_buf_slot(std::size_t id, std::string ubo, int slot) {
+void nre::gpu::set_program_uniform_buf_slot(std::size_t id, const std::string& ubo, int slot) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setProgramUniformBlockSlot(id, ubo, slot);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_program_uniform_block_slot(id, ubo, slot);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_program_uniform_buf_slot", "OpenGL ES 2",
@@ -465,11 +466,11 @@ void nre::gpu::set_program_uniform_buf_slot(std::size_t id, std::string ubo, int
         return;
     }
 }
-int nre::gpu::get_program_uniform_buf_slot(std::size_t id, std::string name) {
+int nre::gpu::get_program_uniform_buf_slot(std::size_t id, const std::string& name) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->getProgramUniformBlockSlot(id, name);
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->get_program_uniform_block_slot(id, name);
     case GLES2:
         throw nre::gpu::unimplemented_function("get_program_uniform_buf_slot", "OpenGL ES 2",
                                                "Uniform buffers are not supported on ES 2.");
@@ -477,14 +478,14 @@ int nre::gpu::get_program_uniform_buf_slot(std::size_t id, std::string name) {
         return -2;
     }
 }
-void nre::gpu::set_program_texture_slot(std::size_t id, std::string name, int slot) {
+void nre::gpu::set_program_texture_slot(std::size_t id, const std::string& name, int slot) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setProgramTextureSlot(id, name, slot);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_program_texture_slot(id, name, slot);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setProgramTextureSlot(id, name, slot);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_program_texture_slot(id, name, slot);
         break;
     default:
         return;
@@ -492,37 +493,37 @@ void nre::gpu::set_program_texture_slot(std::size_t id, std::string name, int sl
 }
 
 // program uniform data
-void nre::gpu::set_program_uniform_data(std::size_t id, std::string name, uint32_t data) {
+void nre::gpu::set_program_uniform_data(std::size_t id, const std::string& name, uint32_t data) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setProgramUniformData(id, name, data);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_program_uniform_data(id, name, data);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setProgramUniformData(id, name, data);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_program_uniform_data(id, name, data);
         break;
     default:
         return;
     }
 }
-void nre::gpu::set_program_uniform_data(std::size_t id, std::string name, float data) {
+void nre::gpu::set_program_uniform_data(std::size_t id, const std::string& name, float data) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setProgramUniformData(id, name, data);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_program_uniform_data(id, name, data);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setProgramUniformData(id, name, data);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_program_uniform_data(id, name, data);
         break;
     default:
         return;
     }
 }
-void nre::gpu::set_program_uniform_data(std::size_t id, std::string name, const std::vector<uint32_t>& data) {
+void nre::gpu::set_program_uniform_data(std::size_t id, const std::string& name, const std::vector<uint32_t>& data) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setProgramUniformData(id, name, data);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_program_uniform_data(id, name, data);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("set_program_uniform_data", "OpenGL ES 2",
@@ -531,29 +532,29 @@ void nre::gpu::set_program_uniform_data(std::size_t id, std::string name, const 
         return;
     }
 }
-void nre::gpu::set_program_uniform_data(std::size_t id, std::string name, const std::vector<float>& data) {
+void nre::gpu::set_program_uniform_data(std::size_t id, const std::string& name, const std::vector<float>& data) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
         throw nre::gpu::unimplemented_function("set_program_uniform_data",
-                                               static_cast<NRE_GL3_API*>(nre::gpu::api)->getRenderingAPI(),
+                                               static_cast<nre::gl3::api_t*>(nre::gpu::api)->get_rendering_api(),
                                                "Uniform float array data is not implemented due to boredom.");
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setProgramUniformData(id, name, data);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_program_uniform_data(id, name, data);
         break;
     default:
         return;
     }
 }
 
-int nre::gpu::get_program_uniform_slot(std::size_t id, std::string name) {
+int nre::gpu::get_program_uniform_slot(std::size_t id, const std::string& name) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        return static_cast<NRE_GL3_API*>(nre::gpu::api)->getProgramUniformSlot(id, name);
+        return static_cast<nre::gl3::api_t*>(nre::gpu::api)->get_program_uniform_slot(id, name);
     case GLES2:
-        return static_cast<NRE_GLES2_API*>(nre::gpu::api)->getProgramUniformSlot(id, name);
+        return static_cast<nre::gles2::api_t*>(nre::gpu::api)->get_program_uniform_slot(id, name);
 
     default:
         return -2;
@@ -565,10 +566,10 @@ void nre::gpu::set_vertex_layout_format(std::size_t id, std::vector<vertex_layou
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setVertexLayoutFormat(id, vao_input);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_vertex_layout_format(id, vao_input);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setVertexLayoutFormat(id, vao_input);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_vertex_layout_format(id, vao_input);
         break;
     default:
         return;
@@ -578,10 +579,10 @@ void nre::gpu::del_vertex_layout(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteVertexLayout(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_vertex_layout(id);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->deleteVertexLayout(id);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->delete_vertex_layout(id);
         break;
     default:
         return;
@@ -594,10 +595,10 @@ void nre::gpu::set_texture_format(std::size_t id, TEXTURE_TYPE textype, TEXTURE_
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setTextureFormat(id, textype, texfil, x, y, mipmaps);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_texture_format(id, textype, texfil, x, y, mipmaps);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setTextureFormat(id, textype, texfil, x, y, mipmaps);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_texture_format(id, textype, texfil, x, y, mipmaps);
         break;
     default:
         return;
@@ -607,10 +608,10 @@ void nre::gpu::set_texture_slot(std::size_t id, int slot) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setTextureSlot(id, slot);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_texture_slot(id, slot);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setTextureSlot(id, slot);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_texture_slot(id, slot);
         break;
     default:
         return;
@@ -620,10 +621,10 @@ void nre::gpu::del_texture(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteTexture(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_texture(id);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->deleteTexture(id);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->delete_texture(id);
         break;
     default:
         return;
@@ -635,10 +636,10 @@ void nre::gpu::set_framebuffer_texture(std::size_t id, std::size_t tex, int slot
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setFrameBufferTexture(id, tex, slot);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_framebuffer_texture(id, tex, slot);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setFrameBufferTexture(id, tex, slot);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_framebuffer_texture(id, tex, slot);
         break;
     default:
         return;
@@ -648,7 +649,7 @@ void nre::gpu::copy_framebuffer(std::size_t src, std::size_t target, FRAMEBUFFER
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->copyFrameBuffer(src, target, method);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->copy_framebuffer(src, target, method);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("copy_framebuffer", "OpenGL ES 2",
@@ -661,10 +662,10 @@ void nre::gpu::use_framebuffer(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->useFrameBuffer(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->use_framebuffer(id);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->useFrameBuffer(id);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->use_framebuffer(id);
         break;
     default:
         return;
@@ -674,10 +675,10 @@ void nre::gpu::clear_framebuffer(std::size_t id, nre::gpu::FRAMEBUFFER_COPY fbco
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->clearFrameBuffer(id, fbcopy, alpha);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->clear_framebuffer(id, fbcopy, alpha);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->clearFrameBuffer(id, fbcopy, alpha);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->clear_framebuffer(id, fbcopy, alpha);
         break;
     default:
         return;
@@ -687,10 +688,10 @@ void nre::gpu::del_framebuffer(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteFrameBuffer(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_framebuffer(id);
         break;
     case GLES2:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteFrameBuffer(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_framebuffer(id);
         break;
     default:
         return;
@@ -703,10 +704,10 @@ void nre::gpu::set_program_vertex_shader(std::size_t id, nre::gpu::vertex_shader
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setProgramVS(id, vs);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_program_vs(id, vs);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setProgramVS(id, vs);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_program_vs(id, vs);
         break;
     default:
         return;
@@ -717,10 +718,10 @@ void nre::gpu::set_program_pixel_shader(std::size_t id, nre::gpu::pixel_shader_t
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setProgramFS(id, fs);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_program_fs(id, fs);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setProgramFS(id, fs);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_program_fs(id, fs);
         break;
     default:
         return;
@@ -730,10 +731,10 @@ void nre::gpu::setup_program(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setupProgram(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->setup_program(id);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setupProgram(id);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->setup_program(id);
         break;
     default:
         return;
@@ -743,10 +744,10 @@ void nre::gpu::del_program(std::size_t id) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->deleteProgram(id);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->delete_program(id);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->deleteProgram(id);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->delete_program(id);
         break;
     default:
         return;
@@ -759,15 +760,16 @@ void nre::gpu::draw(nre::gpu::draw_call dcall) {
     case GLES:
         if ((dcall.offset == 0) and (dcall.amount == 0)) {
             if (dcall.index_buf == 0)
-                static_cast<NRE_GL3_API*>(nre::gpu::api)->draw(dcall.program, dcall.vertex_layout);
+                static_cast<nre::gl3::api_t*>(nre::gpu::api)->draw(dcall.program, dcall.vertex_layout);
             else
-                static_cast<NRE_GL3_API*>(nre::gpu::api)->draw(dcall.program, dcall.vertex_layout, dcall.index_buf);
+                static_cast<nre::gl3::api_t*>(nre::gpu::api)->draw(dcall.program, dcall.vertex_layout, dcall.index_buf);
         }
         else {
             if (dcall.index_buf == 0)
-                static_cast<NRE_GL3_API*>(nre::gpu::api)->draw(dcall.program, dcall.vertex_layout, dcall.offset, dcall.amount);
+                static_cast<nre::gl3::api_t*>(nre::gpu::api)
+                    ->draw(dcall.program, dcall.vertex_layout, dcall.offset, dcall.amount);
             else
-                static_cast<NRE_GL3_API*>(nre::gpu::api)
+                static_cast<nre::gl3::api_t*>(nre::gpu::api)
                     ->draw(dcall.program, dcall.vertex_layout, dcall.index_buf, dcall.offset, dcall.amount);
         }
         break;
@@ -786,10 +788,10 @@ void nre::gpu::draw(std::size_t prog, std::size_t vao) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->draw(prog, vao);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->draw(prog, vao);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->draw(dcall);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->draw(dcall);
         break;
 
     default:
@@ -806,10 +808,10 @@ void nre::gpu::draw(std::size_t prog, std::size_t vao, std::size_t ibo) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->draw(prog, vao, ibo);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->draw(prog, vao, ibo);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->draw(dcall);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->draw(dcall);
         break;
     default:
         return;
@@ -822,21 +824,21 @@ void nre::gpu::draw_instanced(draw_call dcall, int count) {
     case GLES:
         if ((dcall.offset == 0) and (dcall.amount == 0)) {
             if (dcall.index_buf == 0)
-                static_cast<NRE_GL3_API*>(nre::gpu::api)->draw_instanced(dcall.program, dcall.vertex_layout, count);
+                static_cast<nre::gl3::api_t*>(nre::gpu::api)->draw_instanced(dcall.program, dcall.vertex_layout, count);
             else
-                static_cast<NRE_GL3_API*>(nre::gpu::api)
+                static_cast<nre::gl3::api_t*>(nre::gpu::api)
                     ->draw_instanced(dcall.program, dcall.vertex_layout, count, dcall.index_buf);
         }
         else {
             if (dcall.index_buf == 0)
                 // TODO: Error unimplemented function
                 throw nre::gpu::unimplemented_function("draw_instanced",
-                                                       static_cast<NRE_GL3_API*>(nre::gpu::api)->getRenderingAPI(),
+                                                       static_cast<nre::gl3::api_t*>(nre::gpu::api)->get_rendering_api(),
                                                        "No instanced range rendering supported.");
             else
                 // TODO: Error unimplemented function
                 throw nre::gpu::unimplemented_function("draw_instanced",
-                                                       static_cast<NRE_GL3_API*>(nre::gpu::api)->getRenderingAPI(),
+                                                       static_cast<nre::gl3::api_t*>(nre::gpu::api)->get_rendering_api(),
                                                        "No instanced range rendering supported.");
         }
         break;
@@ -851,7 +853,7 @@ void nre::gpu::draw_instanced(std::size_t prog, std::size_t vao, std::size_t ibo
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->draw_instanced(prog, vao, ibo, count);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->draw_instanced(prog, vao, ibo, count);
         break;
     case GLES2:
         throw nre::gpu::unimplemented_function("draw_instanced", "OpenGL ES 2", "Instanced rendering is not supported.");
@@ -864,10 +866,10 @@ void nre::gpu::set_render_mode(RENDERMODE mode) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->setRenderMode(mode);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->set_render_mode(mode);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->setRenderMode(mode);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->set_render_mode(mode);
         break;
     default:
         return;
@@ -878,10 +880,10 @@ void nre::gpu::use_wireframe(bool mode) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<NRE_GL3_API*>(nre::gpu::api)->use_wireframe(mode);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->use_wireframe(mode);
         break;
     case GLES2:
-        static_cast<NRE_GLES2_API*>(nre::gpu::api)->use_wireframe(mode);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->use_wireframe(mode);
         break;
     default:
         return;

--- a/src/Renderer/api_gpu.cpp
+++ b/src/Renderer/api_gpu.cpp
@@ -2,11 +2,9 @@
 #include <OE/Renderer/GLES2/api_gles2.h>
 #include <OE/Renderer/api_gpu.h>
 
-uint32_t              nre::gpu::x             = 0;
-uint32_t              nre::gpu::y             = 0;
-void*                 nre::gpu::api           = nullptr;
-std::atomic<bool>     nre::gpu::use_wireframe = false;
-nre::gpu::info_struct nre::gpu::backend_info  = nre::gpu::info_struct();
+
+void*                 nre::gpu::api          = nullptr;
+nre::gpu::info_struct nre::gpu::backend_info = nre::gpu::info_struct();
 
 nre::gpu::vertex_layout_input::vertex_layout_input() {
 }
@@ -862,6 +860,20 @@ void nre::gpu::set_render_mode(RENDERMODE mode) {
         break;
     case GLES2:
         static_cast<NRE_GLES2_API*>(nre::gpu::api)->setRenderMode(mode);
+        break;
+    default:
+        return;
+    }
+}
+
+void nre::gpu::use_wireframe(bool mode) {
+    switch (nre::gpu::get_api()) {
+    case GL:
+    case GLES:
+        static_cast<NRE_GL3_API*>(nre::gpu::api)->use_wireframe(mode);
+        break;
+    case GLES2:
+        static_cast<NRE_GLES2_API*>(nre::gpu::api)->use_wireframe(mode);
         break;
     default:
         return;

--- a/src/Renderer/api_gpu.cpp
+++ b/src/Renderer/api_gpu.cpp
@@ -178,14 +178,14 @@ bool nre::gpu::init(SHADER_BACKEND backend_in, int major, int minor) {
     return true;
 }
 
-void nre::gpu::update(uint32_t x, uint32_t y) {
+void nre::gpu::update(uint32_t x, uint32_t y, bool sanity_checks) {
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
-        static_cast<nre::gl3::api_t*>(nre::gpu::api)->update(x, y);
+        static_cast<nre::gl3::api_t*>(nre::gpu::api)->update(x, y, sanity_checks);
         break;
     case GLES2:
-        static_cast<nre::gles2::api_t*>(nre::gpu::api)->update(x, y);
+        static_cast<nre::gles2::api_t*>(nre::gpu::api)->update(x, y, sanity_checks);
         break;
     default:
         return;

--- a/src/Renderer/api_gpu.cpp
+++ b/src/Renderer/api_gpu.cpp
@@ -693,6 +693,7 @@ void nre::gpu::del_framebuffer(std::size_t id) {
 
 // vertex shaders
 void nre::gpu::set_program_vertex_shader(std::size_t id, nre::gpu::vertex_shader vs) {
+    // std::cout << "VS HASH " << std::bitset<64>(vs.gen_hash()) << " " << vs.info() << std::endl;
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:
@@ -706,6 +707,7 @@ void nre::gpu::set_program_vertex_shader(std::size_t id, nre::gpu::vertex_shader
     }
 }
 void nre::gpu::set_program_pixel_shader(std::size_t id, nre::gpu::pixel_shader fs) {
+    // std::cout << "FS HASH " << std::bitset<64>(fs.gen_hash()) << " " << fs.info() << std::endl;
     switch (nre::gpu::get_api()) {
     case GL:
     case GLES:

--- a/src/Renderer/api_gpu.cpp
+++ b/src/Renderer/api_gpu.cpp
@@ -6,6 +6,14 @@
 void*                 nre::gpu::api          = nullptr;
 nre::gpu::info_struct nre::gpu::backend_info = nre::gpu::info_struct();
 
+int nre::gpu::get_minor_api_version() {
+    return nre::gpu::backend_info.minor;
+}
+
+int nre::gpu::get_major_api_version() {
+    return nre::gpu::backend_info.major;
+}
+
 nre::gpu::vertex_layout_input::vertex_layout_input() {
 }
 
@@ -150,7 +158,7 @@ bool nre::gpu::init(SHADER_BACKEND backend_in, int major, int minor) {
     info_backend.minor          = minor;
     nre::gpu::backend_info      = info_backend;
 
-    nre::gpu::shader_base::init(backend_in, major, minor);
+    // nre::gpu::shader_base_t::init(backend_in, major, minor);
 
     switch (nre::gpu::get_api()) {
     case GL:
@@ -690,7 +698,7 @@ void nre::gpu::del_framebuffer(std::size_t id) {
 }
 
 // vertex shaders
-void nre::gpu::set_program_vertex_shader(std::size_t id, nre::gpu::vertex_shader vs) {
+void nre::gpu::set_program_vertex_shader(std::size_t id, nre::gpu::vertex_shader_t vs) {
     // std::cout << "VS HASH " << std::bitset<64>(vs.gen_hash()) << " " << vs.info() << std::endl;
     switch (nre::gpu::get_api()) {
     case GL:
@@ -704,7 +712,7 @@ void nre::gpu::set_program_vertex_shader(std::size_t id, nre::gpu::vertex_shader
         return;
     }
 }
-void nre::gpu::set_program_pixel_shader(std::size_t id, nre::gpu::pixel_shader fs) {
+void nre::gpu::set_program_pixel_shader(std::size_t id, nre::gpu::pixel_shader_t fs) {
     // std::cout << "FS HASH " << std::bitset<64>(fs.gen_hash()) << " " << fs.info() << std::endl;
     switch (nre::gpu::get_api()) {
     case GL:

--- a/src/Renderer/drawcall_container.cpp
+++ b/src/Renderer/drawcall_container.cpp
@@ -9,7 +9,7 @@ NRE_DrawCallContainer::NRE_DrawCallContainer() {
 NRE_DrawCallContainer::~NRE_DrawCallContainer() {
 }
 
-NRE_DrawCallContainer::Iterator::Iterator(NRE_DrawCallContainer& db, set_iter_t beginning) : iter(beginning), db_(db) {
+NRE_DrawCallContainer::Iterator::Iterator(set_iter_t beginning) : iter(beginning){
 }
 
 NRE_DrawCallContainer::Iterator& NRE_DrawCallContainer::Iterator::operator++() {
@@ -33,11 +33,11 @@ bool operator!=(const NRE_DrawCallContainer::Iterator& a, const NRE_DrawCallCont
 };
 
 NRE_DrawCallContainer::Iterator NRE_DrawCallContainer::begin() {
-    return Iterator(*this, this->data_.begin());
+    return Iterator(this->data_.begin());
 }
 
 NRE_DrawCallContainer::Iterator NRE_DrawCallContainer::end() {
-    return Iterator(*this, this->data_.end());
+    return Iterator(this->data_.end());
 }
 
 bool NRE_DrawCallContainer::contains(const NRE_RenderGroup& ren_group) {

--- a/src/Renderer/drawcall_container.cpp
+++ b/src/Renderer/drawcall_container.cpp
@@ -9,7 +9,7 @@ NRE_DrawCallContainer::NRE_DrawCallContainer() {
 NRE_DrawCallContainer::~NRE_DrawCallContainer() {
 }
 
-NRE_DrawCallContainer::Iterator::Iterator(set_iter_t beginning) : iter(beginning){
+NRE_DrawCallContainer::Iterator::Iterator(set_iter_t beginning) : iter(beginning) {
 }
 
 NRE_DrawCallContainer::Iterator& NRE_DrawCallContainer::Iterator::operator++() {

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -31,7 +31,6 @@ bool NRE_RendererLegacy::init(oe::renderer_init_info init_info, oe::renderer_upd
     this->initGammaCorrectionProg();
 
     this->initGPUSphere();
-
     return true;
 }
 

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -127,14 +127,17 @@ bool NRE_RendererLegacy::update_data(oe::renderer_update_info update_info, oe::w
     this->render_bounding_spheres = update_info.render_bounding_spheres;
     this->use_HDR                 = update_info.use_hdr;
     this->use_z_prepass           = update_info.use_z_prepass;
-    bool temp_restart_renderer    = has_renderer_restarted or (this->shading_mode != update_info.shading_mode);
+    bool temp_restart_renderer    = (this->shading_mode != update_info.shading_mode);
 
     if (temp_restart_renderer) {
         this->destroy();
         this->init(this->init_info, update_info, winsys_info);
     }
+    else if (has_renderer_restarted) {
+        this->init(this->init_info, update_info, winsys_info);
+    }
     this->shading_mode = update_info.shading_mode;
-    data_.update(temp_restart_renderer, this->render_bounding_boxes or this->render_bounding_spheres);
+    data_.update(temp_restart_renderer or has_renderer_restarted, this->render_bounding_boxes or this->render_bounding_spheres);
 
     return true;
 }

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -155,7 +155,7 @@ bool NRE_RendererLegacy::update_single_thread(oe::renderer_update_info update_in
     this->use_HDR                 = update_info.use_hdr;
     this->use_z_prepass           = update_info.use_z_prepass;
 
-    nre::gpu::update(res_x_, res_y_);
+    nre::gpu::update(res_x_, res_y_, update_info.sanity_checks);
 
     if (not this->use_HDR) {
         nre::gpu::set_texture_format(this->colortexture, nre::gpu::RGBA, nre::gpu::NEAREST, res_x_, res_y_, 0);

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -290,19 +290,19 @@ void NRE_RendererLegacy::drawRenderGroup(NRE_RenderGroup& ren_group) {
         ren_group.fs = nre::gpu::pixel_shader_t();
         lockMutex();
         switch (this->shading_mode) {
-        case OE_RENDERER_NORMALS_SHADING:
+        case oe::RENDERER_NORMALS_SHADING:
             ren_group.fs.type = nre::gpu::FS_NORMALS;
             break;
-        case OE_RENDERER_NO_LIGHTS_SHADING:
+        case oe::RENDERER_NO_LIGHTS_SHADING:
             ren_group.fs.type = nre::gpu::FS_MATERIAL;
             break;
-        case OE_RENDERER_DIR_LIGHTS_SHADING:
+        case oe::RENDERER_DIR_LIGHTS_SHADING:
 
             break;
-        case OE_RENDERER_INDEXED_LIGHTS_SHADING:
+        case oe::RENDERER_INDEXED_LIGHTS_SHADING:
 
             break;
-        case OE_RENDERER_REGULAR_SHADING:
+        case oe::RENDERER_REGULAR_SHADING:
             ren_group.fs.type = nre::gpu::FS_MATERIAL;
             break;
         }

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -117,8 +117,8 @@ void NRE_RendererLegacy::initGPUSphere() {
 
 //------------------------updateData---------------------------//
 
-bool NRE_RendererLegacy::updateData(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
-                                    bool has_renderer_restarted) {
+bool NRE_RendererLegacy::update_data(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
+                                     bool has_renderer_restarted) {
     assert(this->world != nullptr);
     res_x_ = winsys_info.res_x;
     res_y_ = winsys_info.res_y;
@@ -142,7 +142,7 @@ bool NRE_RendererLegacy::updateData(oe::renderer_update_info update_info, oe::wi
 
 //------------------------updateSIngleThread-------------------//
 
-bool NRE_RendererLegacy::updateSingleThread(oe::renderer_update_info update_info, oe::winsys_output winsys_info) {
+bool NRE_RendererLegacy::update_single_thread(oe::renderer_update_info update_info, oe::winsys_output winsys_info) {
 
     res_x_ = winsys_info.res_x;
     res_y_ = winsys_info.res_y;
@@ -621,7 +621,7 @@ void NRE_RendererLegacy::updateLightGPUData() {
     }
 }
 
-bool NRE_RendererLegacy::updateMultiThread(OE_Task*, int) {
+bool NRE_RendererLegacy::update_multi_thread(OE_Task*, int) {
     return false;
 }
 

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -46,16 +46,16 @@ void NRE_RendererLegacy::initOffscreenFrameBuffer() {
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
     else {
         nre::gpu::set_texture_format(this->colortexture, nre::gpu::RGBA16F, nre::gpu::NEAREST, this->screen->resolution_x,
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
 
     nre::gpu::set_framebuffer_texture(this->framebuffer, this->colortexture, 0);
@@ -147,16 +147,16 @@ bool NRE_RendererLegacy::updateSingleThread() {
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
     else {
         nre::gpu::set_texture_format(this->colortexture, nre::gpu::RGBA16F, nre::gpu::NEAREST, this->screen->resolution_x,
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
     // update light texture
     // nre::gpu::set_texture_format(this->tex_light, nre::gpu::RGBA, nre::gpu::NEAREST, this->screen->resolution_x,

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -173,7 +173,7 @@ bool NRE_RendererLegacy::updateSingleThread() {
 
 
     // render viewport
-    nre::gpu::use_wireframe = this->use_wireframe.load(std::memory_order_relaxed);
+    nre::gpu::use_wireframe(this->use_wireframe.load(std::memory_order_relaxed));
 
     /*cout << "NRE Cameras: " << data_.cameras_.size() << endl;
     cout << "NRE Materials: " << data_.materials_.size() << endl;
@@ -226,10 +226,9 @@ bool NRE_RendererLegacy::updateSingleThread() {
         this->sce_ren_groups[scene_id].update();
 
         // optionally draw a bounding box/sphere for each object (in wireframe mode)
-        bool temp               = nre::gpu::use_wireframe;
-        bool render_bboxes      = this->render_bounding_boxes.load(std::memory_order_relaxed);
-        bool render_spheres     = this->render_bounding_spheres.load(std::memory_order_relaxed);
-        nre::gpu::use_wireframe = true;
+        bool render_bboxes  = this->render_bounding_boxes.load(std::memory_order_relaxed);
+        bool render_spheres = this->render_bounding_spheres.load(std::memory_order_relaxed);
+        nre::gpu::use_wireframe(true);
 
         if (render_bboxes) {
             nre::gpu::set_render_mode(nre::gpu::REGULAR_BOTH);
@@ -261,14 +260,12 @@ bool NRE_RendererLegacy::updateSingleThread() {
             }
             this->sce_ren_groups[scene_id].update();
         }
-
-        nre::gpu::use_wireframe = temp;
     }
 
     // nre::gpu::copyFrameBuffer(this->framebuffer, 0, nre::gpu::FBO_DEPTHSTENCIL);
 
     nre::gpu::use_framebuffer(0);
-    nre::gpu::use_wireframe = false;
+    nre::gpu::use_wireframe(false);
     nre::gpu::set_render_mode(nre::gpu::FULLSCREEN_QUAD);
 
     nre::gpu::set_texture_slot(this->colortexture, 0);

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -81,8 +81,8 @@ void NRE_RendererLegacy::initGammaCorrectionProg() {
     // setup gamma correction program
     this->gamma_cor_prog = nre::gpu::new_program();
 
-    nre::gpu::vertex_shader vs_gamma;
-    nre::gpu::pixel_shader  fs_gamma;
+    nre::gpu::vertex_shader_t vs_gamma;
+    nre::gpu::pixel_shader_t  fs_gamma;
 
     vs_gamma.type           = nre::gpu::VS_UNDEFINED;
     vs_gamma.fullscreenQuad = true;
@@ -281,13 +281,13 @@ void NRE_RendererLegacy::drawRenderGroup(NRE_RenderGroup& ren_group) {
 
         ren_group.isSetup = true;
 
-        ren_group.vs            = nre::gpu::vertex_shader();
+        ren_group.vs            = nre::gpu::vertex_shader_t();
         ren_group.vs.type       = nre::gpu::VS_REGULAR;
         ren_group.vs.num_of_uvs = data_.meshes_[ren_group.mesh].uvmaps;
 
 
         // choose shading mode
-        ren_group.fs = nre::gpu::pixel_shader();
+        ren_group.fs = nre::gpu::pixel_shader_t();
         lockMutex();
         switch (this->shading_mode) {
         case OE_RENDERER_NORMALS_SHADING:
@@ -342,7 +342,7 @@ void NRE_RendererLegacy::drawRenderGroupZPrePass(NRE_RenderGroup& ren_group) {
 
         ren_group.isZPrePassSetup = true;
 
-        ren_group.vs_z_prepass            = nre::gpu::vertex_shader();
+        ren_group.vs_z_prepass            = nre::gpu::vertex_shader_t();
         ren_group.vs_z_prepass.type       = nre::gpu::VS_Z_PREPASS;
         ren_group.vs_z_prepass.num_of_uvs = data_.meshes_[ren_group.mesh].uvmaps;
 
@@ -404,8 +404,8 @@ void NRE_RendererLegacy::setupBoundingBoxProgram() {
 
     this->prog_bbox = nre::gpu::new_program();
 
-    nre::gpu::vertex_shader vs_bbox;
-    nre::gpu::pixel_shader  fs_bbox;
+    nre::gpu::vertex_shader_t vs_bbox;
+    nre::gpu::pixel_shader_t  fs_bbox;
 
     vs_bbox.type       = nre::gpu::VS_BOUNDING_BOX;
     vs_bbox.num_of_uvs = 0;
@@ -423,8 +423,8 @@ void NRE_RendererLegacy::setupBoundingSphereProgram() {
 
     this->prog_sphere = nre::gpu::new_program();
 
-    nre::gpu::vertex_shader vs_sphere;
-    nre::gpu::pixel_shader  fs_sphere;
+    nre::gpu::vertex_shader_t vs_sphere;
+    nre::gpu::pixel_shader_t  fs_sphere;
 
     vs_sphere.type       = nre::gpu::VS_BOUNDING_SPHERE;
     vs_sphere.num_of_uvs = 0;

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -43,16 +43,16 @@ void NRE_Renderer::initOffscreenFrameBuffer() {
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
     else {
         nre::gpu::set_texture_format(this->colortexture, nre::gpu::RGBA16F, nre::gpu::NEAREST, this->screen->resolution_x,
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
 
     nre::gpu::set_framebuffer_texture(this->framebuffer, this->colortexture, 0);
@@ -181,16 +181,16 @@ bool NRE_Renderer::updateSingleThread() {
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
     else {
         nre::gpu::set_texture_format(this->colortexture, nre::gpu::RGBA16F, nre::gpu::NEAREST, this->screen->resolution_x,
                                      this->screen->resolution_y, 0);
         // nre::gpu::set_texture_format(this->depthtexture, nre::gpu::DEPTHSTENCIL, nre::gpu::NEAREST,
         // this->screen->resolution_x, this->screen->resolution_y, 0);
-        nre::gpu::set_renderbuffer_mode(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
-                                        this->screen->resolution_y);
+        nre::gpu::set_renderbuffer_textype(this->depthrbo, nre::gpu::DEPTHSTENCIL, this->screen->resolution_x,
+                                           this->screen->resolution_y);
     }
     // update light texture
     nre::gpu::set_texture_format(this->tex_light, nre::gpu::RGBA, nre::gpu::NEAREST, this->screen->resolution_x,

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -28,7 +28,6 @@ bool NRE_Renderer::init(oe::renderer_init_info init_info, oe::renderer_update_in
     this->initGammaCorrectionProg();
     this->initGPUSphere();
     this->initLightUBOProgramFBO();
-
     return true;
 }
 

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -149,22 +149,25 @@ void NRE_Renderer::initLightUBOProgramFBO() {
 bool NRE_Renderer::update_data(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
                                bool has_renderer_restarted) {
     assert(this->world != nullptr);
-    bool temp_restart_renderer = has_renderer_restarted or (this->shading_mode != update_info.shading_mode);
-    res_x_                     = winsys_info.res_x;
-    res_y_                     = winsys_info.res_y;
+    res_x_ = winsys_info.res_x;
+    res_y_ = winsys_info.res_y;
 
     this->use_wireframe           = update_info.use_wireframe;
     this->render_bounding_boxes   = update_info.render_bounding_boxes;
     this->render_bounding_spheres = update_info.render_bounding_spheres;
     this->use_HDR                 = update_info.use_hdr;
     this->use_z_prepass           = update_info.use_z_prepass;
+    bool temp_restart_renderer    = (this->shading_mode != update_info.shading_mode);
 
     if (temp_restart_renderer) {
         this->destroy();
         this->init(this->init_info, update_info, winsys_info);
     }
+    else if (has_renderer_restarted) {
+        this->init(this->init_info, update_info, winsys_info);
+    }
     this->shading_mode = update_info.shading_mode;
-    data_.update(temp_restart_renderer, this->render_bounding_boxes or this->render_bounding_spheres);
+    data_.update(temp_restart_renderer or has_renderer_restarted, this->render_bounding_boxes or this->render_bounding_spheres);
 
     return true;
 }

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -147,8 +147,8 @@ void NRE_Renderer::initLightUBOProgramFBO() {
 
 //------------------------updateData---------------------------//
 
-bool NRE_Renderer::updateData(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
-                              bool has_renderer_restarted) {
+bool NRE_Renderer::update_data(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
+                               bool has_renderer_restarted) {
     assert(this->world != nullptr);
     bool temp_restart_renderer = has_renderer_restarted or (this->shading_mode != update_info.shading_mode);
     res_x_                     = winsys_info.res_x;
@@ -172,7 +172,7 @@ bool NRE_Renderer::updateData(oe::renderer_update_info update_info, oe::winsys_o
 
 //------------------------updateSIngleThread-------------------//
 
-bool NRE_Renderer::updateSingleThread(oe::renderer_update_info update_info, oe::winsys_output winsys_info) {
+bool NRE_Renderer::update_single_thread(oe::renderer_update_info update_info, oe::winsys_output winsys_info) {
 
     res_x_ = winsys_info.res_x;
     res_y_ = winsys_info.res_y;
@@ -680,7 +680,7 @@ void NRE_Renderer::updateLightGPUData() {
     nre::gpu::set_uniform_buf_data(this->pt_light_ubo, pt_light_data, 0);
 }
 
-bool NRE_Renderer::updateMultiThread(OE_Task*, int) {
+bool NRE_Renderer::update_multi_thread(OE_Task*, int) {
     return false;
 }
 

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -79,8 +79,8 @@ void NRE_Renderer::initGammaCorrectionProg() {
     // setup gamma correction program
     this->gamma_cor_prog = nre::gpu::new_program();
 
-    nre::gpu::vertex_shader vs_gamma;
-    nre::gpu::pixel_shader  fs_gamma;
+    nre::gpu::vertex_shader_t vs_gamma;
+    nre::gpu::pixel_shader_t  fs_gamma;
 
     vs_gamma.type           = nre::gpu::VS_UNDEFINED;
     vs_gamma.fullscreenQuad = true;
@@ -124,8 +124,8 @@ void NRE_Renderer::initLightUBOProgramFBO() {
     // setup light program
     this->prog_light = nre::gpu::new_program();
 
-    nre::gpu::vertex_shader vs_light;
-    nre::gpu::pixel_shader  fs_light;
+    nre::gpu::vertex_shader_t vs_light;
+    nre::gpu::pixel_shader_t  fs_light;
 
     vs_light.type       = nre::gpu::VS_LIGHT;
     vs_light.num_of_uvs = 0;
@@ -335,13 +335,13 @@ void NRE_Renderer::drawRenderGroup(NRE_RenderGroup& ren_group) {
 
         ren_group.isSetup = true;
 
-        ren_group.vs            = nre::gpu::vertex_shader();
+        ren_group.vs            = nre::gpu::vertex_shader_t();
         ren_group.vs.type       = nre::gpu::VS_REGULAR;
         ren_group.vs.num_of_uvs = data_.meshes_[ren_group.mesh].uvmaps;
 
 
         // choose shading mode
-        ren_group.fs = nre::gpu::pixel_shader();
+        ren_group.fs = nre::gpu::pixel_shader_t();
         lockMutex();
         switch (this->shading_mode) {
         case OE_RENDERER_NORMALS_SHADING:
@@ -387,7 +387,7 @@ void NRE_Renderer::drawRenderGroupZPrePass(NRE_RenderGroup& ren_group) {
 
         ren_group.isZPrePassSetup = true;
 
-        ren_group.vs_z_prepass            = nre::gpu::vertex_shader();
+        ren_group.vs_z_prepass            = nre::gpu::vertex_shader_t();
         ren_group.vs_z_prepass.type       = nre::gpu::VS_Z_PREPASS;
         ren_group.vs_z_prepass.num_of_uvs = data_.meshes_[ren_group.mesh].uvmaps;
 
@@ -441,8 +441,8 @@ void NRE_Renderer::setupBoundingBoxProgram() {
 
     this->prog_bbox = nre::gpu::new_program();
 
-    nre::gpu::vertex_shader vs_bbox;
-    nre::gpu::pixel_shader  fs_bbox;
+    nre::gpu::vertex_shader_t vs_bbox;
+    nre::gpu::pixel_shader_t  fs_bbox;
 
     vs_bbox.type       = nre::gpu::VS_BOUNDING_BOX;
     vs_bbox.num_of_uvs = 0;
@@ -465,8 +465,8 @@ void NRE_Renderer::setupBoundingSphereProgram() {
 
     this->prog_sphere = nre::gpu::new_program();
 
-    nre::gpu::vertex_shader vs_sphere;
-    nre::gpu::pixel_shader  fs_sphere;
+    nre::gpu::vertex_shader_t vs_sphere;
+    nre::gpu::pixel_shader_t  fs_sphere;
 
     vs_sphere.type       = nre::gpu::VS_BOUNDING_SPHERE;
     vs_sphere.num_of_uvs = 0;

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -207,7 +207,7 @@ bool NRE_Renderer::updateSingleThread() {
 
 
     // render viewport
-    nre::gpu::use_wireframe = this->use_wireframe.load(std::memory_order_relaxed);
+    nre::gpu::use_wireframe(this->use_wireframe.load(std::memory_order_relaxed));
 
     /*cout << "NRE Cameras: " << data_.cameras.size() << endl;
     cout << "NRE Materials: " << data_.materials.size() << endl;
@@ -279,10 +279,9 @@ bool NRE_Renderer::updateSingleThread() {
         this->sce_ren_groups[scene_id].update();
 
         // optionally draw a bounding box/sphere for each object (in wireframe mode)
-        bool temp               = nre::gpu::use_wireframe;
-        bool render_bboxes      = this->render_bounding_boxes.load(std::memory_order_relaxed);
-        bool render_spheres     = this->render_bounding_spheres.load(std::memory_order_relaxed);
-        nre::gpu::use_wireframe = true;
+        bool render_bboxes  = this->render_bounding_boxes.load(std::memory_order_relaxed);
+        bool render_spheres = this->render_bounding_spheres.load(std::memory_order_relaxed);
+        nre::gpu::use_wireframe(true);
 
         if (render_bboxes) {
             nre::gpu::set_render_mode(nre::gpu::REGULAR_BOTH);
@@ -314,14 +313,12 @@ bool NRE_Renderer::updateSingleThread() {
             }
             this->sce_ren_groups[scene_id].update();
         }
-
-        nre::gpu::use_wireframe = temp;
     }
 
     // nre::gpu::copyFrameBuffer(this->framebuffer, 0, nre::gpu::FBO_DEPTHSTENCIL);
 
     nre::gpu::use_framebuffer(0);
-    nre::gpu::use_wireframe = false;
+    nre::gpu::use_wireframe(false);
     nre::gpu::set_render_mode(nre::gpu::FULLSCREEN_QUAD);
 
     nre::gpu::set_texture_slot(this->colortexture, 0);

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -344,19 +344,19 @@ void NRE_Renderer::drawRenderGroup(NRE_RenderGroup& ren_group) {
         ren_group.fs = nre::gpu::pixel_shader_t();
         lockMutex();
         switch (this->shading_mode) {
-        case OE_RENDERER_NORMALS_SHADING:
+        case oe::RENDERER_NORMALS_SHADING:
             ren_group.fs.type = nre::gpu::FS_NORMALS;
             break;
-        case OE_RENDERER_NO_LIGHTS_SHADING:
+        case oe::RENDERER_NO_LIGHTS_SHADING:
             ren_group.fs.type = nre::gpu::FS_MATERIAL;
             break;
-        case OE_RENDERER_DIR_LIGHTS_SHADING:
+        case oe::RENDERER_DIR_LIGHTS_SHADING:
 
             break;
-        case OE_RENDERER_INDEXED_LIGHTS_SHADING:
+        case oe::RENDERER_INDEXED_LIGHTS_SHADING:
 
             break;
-        case OE_RENDERER_REGULAR_SHADING:
+        case oe::RENDERER_REGULAR_SHADING:
             ren_group.fs.type = nre::gpu::FS_MATERIAL;
             break;
         }

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -185,7 +185,7 @@ bool NRE_Renderer::update_single_thread(oe::renderer_update_info update_info, oe
     this->use_HDR                 = update_info.use_hdr;
     this->use_z_prepass           = update_info.use_z_prepass;
 
-    nre::gpu::update(res_x_, res_y_);
+    nre::gpu::update(res_x_, res_y_, update_info.sanity_checks);
 
     if (this->use_HDR == false) {
         nre::gpu::set_texture_format(this->colortexture, nre::gpu::RGB10_A2, nre::gpu::NEAREST, res_x_, res_y_, 0);

--- a/src/Renderer/shaders_gpu.cpp
+++ b/src/Renderer/shaders_gpu.cpp
@@ -46,11 +46,11 @@ void nre::gpu::shader_base::init(SHADER_BACKEND backend, int major, int minor) {
 }
 
 
-std::string nre::gpu::shader_base::gen_shader() {
+std::string nre::gpu::shader_base::gen_shader() const {
     return "";
 }
 
-std::string nre::gpu::shader_base::info() {
+std::string nre::gpu::shader_base::info() const {
     return "";
 }
 

--- a/src/Renderer/shaders_gpu.cpp
+++ b/src/Renderer/shaders_gpu.cpp
@@ -10,74 +10,77 @@ using namespace nre::gpu;
 
 // General boilerplate
 
-std::string nre::gpu::shader_base::shader_prefix = "";
-
-nre::gpu::shader_base::~shader_base() {
+nre::gpu::shader_base_t::~shader_base_t() {
 }
 
-void nre::gpu::shader_base::init(SHADER_BACKEND backend, int major, int minor) {
+std::string nre::gpu::gen_shader_prefix() {
 
+    std::string output;
+    auto        backend = nre::gpu::get_api();
+    int         major   = nre::gpu::get_major_api_version();
+    int         minor   = nre::gpu::get_minor_api_version();
 
     if (backend == GLES) {
-        nre::gpu::shader_base::shader_prefix = "#version 300 es \n";
+        output = "#version 300 es \n";
     }
     else if (backend == GL) {
 
         if (major == 3 && minor == 1) {
-            nre::gpu::shader_base::shader_prefix = "#version 140 \n"
-                                                   "#extension GL_ARB_explicit_attrib_location"
-                                                   ": require\n";
+            output = "#version 140 \n"
+                     "#extension GL_ARB_explicit_attrib_location"
+                     ": require\n";
         }
         else if (major == 3 && minor >= 2) {
-            nre::gpu::shader_base::shader_prefix = "#version 150 core \n"
-                                                   "#extension GL_ARB_explicit_attrib_location"
-                                                   ": require\n";
+            output = "#version 150 core \n"
+                     "#extension GL_ARB_explicit_attrib_location"
+                     ": require\n";
         }
         else {
             cout << "WTF" << endl;
         }
     }
     else if (backend == GLES2) {
-        nre::gpu::shader_base::shader_prefix = "#version 100 \n";
+        output = "#version 100 \n";
     }
     else {
         cout << "Undefined NRE GPU Shader backend. Nothing is rendered" << endl;
     }
+    return output;
 }
 
 
-std::string nre::gpu::shader_base::gen_shader() const {
+std::string nre::gpu::shader_base_t::gen_shader() const {
     return "";
 }
 
-std::string nre::gpu::shader_base::info() const {
+std::string nre::gpu::shader_base_t::info() const {
     return "";
 }
 
 // Vertex Shader
 
-nre::gpu::vertex_shader::vertex_shader() {
+nre::gpu::vertex_shader_t::vertex_shader_t() {
 }
 
-nre::gpu::vertex_shader::~vertex_shader() {
+nre::gpu::vertex_shader_t::~vertex_shader_t() {
 }
 
-bool nre::gpu::vertex_shader::operator==(const nre::gpu::vertex_shader& other) const {
+bool nre::gpu::vertex_shader_t::operator==(const nre::gpu::vertex_shader_t& other) const {
     return std::tie(this->fullscreenQuad, this->type, this->num_of_uvs) ==
            std::tie(other.fullscreenQuad, other.type, other.num_of_uvs);
 }
 
 
-std::string nre::gpu::vertex_shader::gen_shader() const {
+std::string nre::gpu::vertex_shader_t::gen_shader() const {
     if (nre::gpu::get_api() == GL || nre::gpu::get_api() == GLES)
-        return NRE_GenGL3VertexShader(*this);
+        return nre::gl3::gen_vertex_shader(*this);
     else if (nre::gpu::get_api() == GLES2)
-        return NRE_GenGLES2VertexShader(*this);
+        return nre::gles2::gen_vertex_shader(*this);
     else
         return "";
 }
 
-std::string nre::gpu::vertex_shader::info() const {
+std::string nre::gpu::vertex_shader_t::info() const {
 
     stringstream ss;
     switch (this->type) {
@@ -105,7 +108,7 @@ std::string nre::gpu::vertex_shader::info() const {
 }
 
 
-size_t nre::gpu::vertex_shader::gen_hash() const {
+size_t nre::gpu::vertex_shader_t::gen_hash() const {
     // should only use the first 32
     std::bitset<64> output_bits(this->fullscreenQuad);
 
@@ -118,27 +121,27 @@ size_t nre::gpu::vertex_shader::gen_hash() const {
 
 // Fragment/Pixel Shader
 
-nre::gpu::pixel_shader::pixel_shader() {
+nre::gpu::pixel_shader_t::pixel_shader_t() {
 }
 
-nre::gpu::pixel_shader::~pixel_shader() {
+nre::gpu::pixel_shader_t::~pixel_shader_t() {
 }
 
-bool nre::gpu::pixel_shader::operator==(const nre::gpu::pixel_shader& other) const {
+bool nre::gpu::pixel_shader_t::operator==(const nre::gpu::pixel_shader_t& other) const {
     return std::tie(this->type, this->num_of_uvs) == std::tie(other.type, other.num_of_uvs);
 }
 
-std::string nre::gpu::pixel_shader::gen_shader() const {
+std::string nre::gpu::pixel_shader_t::gen_shader() const {
     if (nre::gpu::get_api() == GL || nre::gpu::get_api() == GLES)
-        return NRE_GenGL3PixelShader(*this);
+        return nre::gl3::gen_pixel_shader(*this);
     else if (nre::gpu::get_api() == GLES2)
-        return NRE_GenGLES2PixelShader(*this);
+        return nre::gles2::gen_pixel_shader(*this);
     else
         return "";
     return "";
 }
 
-std::string nre::gpu::pixel_shader::info() const {
+std::string nre::gpu::pixel_shader_t::info() const {
     stringstream ss;
     switch (this->type) {
     case FS_UNDEFINED:
@@ -174,7 +177,7 @@ std::string nre::gpu::pixel_shader::info() const {
 }
 
 
-size_t nre::gpu::pixel_shader::gen_hash() const {
+size_t nre::gpu::pixel_shader_t::gen_hash() const {
     // should only use the last 32
     std::bitset<64> output_bits(0);
 

--- a/src/api_helpers_oe.cpp
+++ b/src/api_helpers_oe.cpp
@@ -18,10 +18,10 @@ int OE_API_Helpers::load_world(OE_Task task, string filename) {
 int OE_API_Helpers::manage_mouse(OE_Task task, std::string event_name) {
 
     if (event_name == "mouse-lock") {
-        OE_Main->window->lockMouse();
+        OE_Main->window->lock_mouse();
     }
     else if (event_name == "mouse-unlock") {
-        OE_Main->window->unlockMouse();
+        OE_Main->window->unlock_mouse();
     }
     return 0;
 }

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -77,12 +77,14 @@ void oe::create_event(std::string name) {
 
 size_t oe::get_event_activations(std::string name) {
     OE_API_Helpers::checkIfInit();
-    return OE_Main->window->event_handler.getEventActivations(name);
+    size_t event_id = OE_Main->window->event_handler.get_event_id(name);
+    return OE_Main->window->event_handler.getEventActivations(event_id);
 }
 
 size_t oe::get_event_counter(std::string name) {
     OE_API_Helpers::checkIfInit();
-    return OE_Main->window->event_handler.getEventCounter(name);
+    size_t event_id = OE_Main->window->event_handler.get_event_id(name);
+    return OE_Main->window->event_handler.getEventCounter(event_id);
 }
 
 bool oe::is_key_just_pressed(std::string key) {
@@ -144,7 +146,8 @@ int oe::get_mouse_y() {
 void oe::destroy_event(std::string name) {
     OE_API_Helpers::checkIfInit();
     OE_Main->window->event_handler.lockMutex();
-    OE_Main->window->event_handler.destroyIEvent(name);
+    size_t event_id = OE_Main->window->event_handler.get_event_id(name);
+    OE_Main->window->event_handler.destroyIEvent(event_id);
     OE_Main->window->event_handler.unlockMutex();
 }
 

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -47,7 +47,7 @@ bool oe::is_done() {
 // ?? Where do i even need this ??? UPDATE: Now I remember
 void oe::finish() {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.done = true;
+    OE_Main->window->event_handler_.done_ = true;
 }
 
 // size_t OE_InitFromFile(std::string); //TODO
@@ -68,23 +68,23 @@ void oe::remove_task(std::string task, std::string thread) {
 
 void oe::broadcast_event(std::string name) {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.broadcastIEvent(name);
+    OE_Main->window->event_handler_.broadcast_ievent(name);
 }
 void oe::create_event(std::string name) {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.createUserEvent(name);
+    OE_Main->window->event_handler_.create_user_event(name);
 }
 
 size_t oe::get_event_activations(std::string name) {
     OE_API_Helpers::checkIfInit();
-    size_t event_id = OE_Main->window->event_handler.get_event_id(name);
-    return OE_Main->window->event_handler.getEventActivations(event_id);
+    size_t event_id = OE_Main->window->event_handler_.get_event_id(name);
+    return OE_Main->window->event_handler_.get_event_activations(event_id);
 }
 
 size_t oe::get_event_counter(std::string name) {
     OE_API_Helpers::checkIfInit();
-    size_t event_id = OE_Main->window->event_handler.get_event_id(name);
-    return OE_Main->window->event_handler.getEventCounter(event_id);
+    size_t event_id = OE_Main->window->event_handler_.get_event_id(name);
+    return OE_Main->window->event_handler_.get_event_counter(event_id);
 }
 
 bool oe::is_key_just_pressed(std::string key) {
@@ -113,42 +113,42 @@ bool oe::is_mouse_moved() {
 
 int oe::get_delta_mouse_x() {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.lockMutex();
-    int output = OE_Main->window->event_handler.get_mouse_delta_x();
-    OE_Main->window->event_handler.unlockMutex();
+    OE_Main->window->event_handler_.lockMutex();
+    int output = OE_Main->window->event_handler_.get_mouse_delta_x();
+    OE_Main->window->event_handler_.unlockMutex();
     return output;
 }
 
 int oe::get_delta_mouse_y() {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.lockMutex();
-    int output = OE_Main->window->event_handler.get_mouse_delta_y();
-    OE_Main->window->event_handler.unlockMutex();
+    OE_Main->window->event_handler_.lockMutex();
+    int output = OE_Main->window->event_handler_.get_mouse_delta_y();
+    OE_Main->window->event_handler_.unlockMutex();
     return output;
 }
 
 int oe::get_mouse_x() {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.lockMutex();
-    int output = OE_Main->window->event_handler.get_mouse_x();
-    OE_Main->window->event_handler.unlockMutex();
+    OE_Main->window->event_handler_.lockMutex();
+    int output = OE_Main->window->event_handler_.get_mouse_x();
+    OE_Main->window->event_handler_.unlockMutex();
     return output;
 }
 
 int oe::get_mouse_y() {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.lockMutex();
-    int output = OE_Main->window->event_handler.get_mouse_y();
-    OE_Main->window->event_handler.unlockMutex();
+    OE_Main->window->event_handler_.lockMutex();
+    int output = OE_Main->window->event_handler_.get_mouse_y();
+    OE_Main->window->event_handler_.unlockMutex();
     return output;
 }
 
 void oe::destroy_event(std::string name) {
     OE_API_Helpers::checkIfInit();
-    OE_Main->window->event_handler.lockMutex();
-    size_t event_id = OE_Main->window->event_handler.get_event_id(name);
-    OE_Main->window->event_handler.destroyIEvent(event_id);
-    OE_Main->window->event_handler.unlockMutex();
+    OE_Main->window->event_handler_.lockMutex();
+    size_t event_id = OE_Main->window->event_handler_.get_event_id(name);
+    OE_Main->window->event_handler_.destroy_ievent(event_id);
+    OE_Main->window->event_handler_.unlockMutex();
 }
 
 void oe::pause(int x) {

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -1,23 +1,38 @@
 #include <OE/api_oe.h>
 #include <OE/math_oe.h>
+#include <OE/types/libs_oe.h>
 
 using namespace oe;
 using namespace std;
 
-OE_TaskManager* oe::OE_Main                      = nullptr;
-bool            oe::preinit::use_legacy_renderer = false;
+OE_TaskManager*          oe::OE_Main                        = nullptr;
+oe::renderer_init_info   oe::preinit::renderer_parameters   = oe::renderer_init_info();
+oe::winsys_init_info     oe::preinit::winsys_parameters     = oe::winsys_init_info();
+oe::physics_init_info    oe::preinit::physics_parameters    = oe::physics_init_info();
+oe::networking_init_info oe::preinit::networking_parameters = oe::networking_init_info();
+
+void oe::preinit::request_gles2() {
+    // NOTE: Windows needs ANGLE to support OpenGL ES. For now let's use the other renderer
+    // ANGLE is not easy to install as a library and use
+#ifndef OE_PLATFORM_WINDOWS
+    oe::preinit::winsys_parameters.requested_backend = nre::gpu::GLES2;
+#endif
+}
 
 size_t oe::init() {
     OE_Main = new OE_TaskManager();
-    return OE_Main->Init("Oxygen Engine Test", 800, 600, false, oe::preinit::use_legacy_renderer);
+    return OE_Main->Init("Oxygen Engine Test", 800, 600, false, preinit::renderer_parameters, preinit::winsys_parameters,
+                         preinit::physics_parameters, oe::preinit::networking_parameters);
 }
 size_t oe::init(std::string title, bool fullscreen) {
     OE_Main = new OE_TaskManager();
-    return OE_Main->Init(title, 800, 600, fullscreen, oe::preinit::use_legacy_renderer);
+    return OE_Main->Init(title, 800, 600, fullscreen, preinit::renderer_parameters, preinit::winsys_parameters,
+                         preinit::physics_parameters, oe::preinit::networking_parameters);
 }
 size_t oe::init(std::string title, int x, int y, bool fullscreen) {
     OE_Main = new OE_TaskManager();
-    return OE_Main->Init(title, x, y, fullscreen, oe::preinit::use_legacy_renderer);
+    return OE_Main->Init(title, x, y, fullscreen, preinit::renderer_parameters, preinit::winsys_parameters,
+                         preinit::physics_parameters, oe::preinit::networking_parameters);
 }
 void oe::step() {
     OE_API_Helpers::checkIfInit();
@@ -157,7 +172,7 @@ void oe::pause(int x) {
 }
 
 bool oe::is_mouse_locked() {
-    return OE_Main->window->getMouseLockedState();
+    return OE_Main->window->is_mouse_locked();
 }
 
 void oe::mouse_lock() {
@@ -543,31 +558,23 @@ void oe::change_object_scale(std::string name, OE_Vec3 sca) {
 void oe::restart_renderer() {
     OE_API_Helpers::checkIfInit();
     OE_Main->window_mutex.lockMutex();
-    if (OE_Main->window != nullptr) OE_Main->window->restart_renderer = true;
+    OE_Main->restart_renderer = true;
     OE_Main->window_mutex.unlockMutex();
 }
 
 void oe::set_shading_mode(oe::RENDERER_SHADING_MODE shading_mode) {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->lockMutex();
-        OE_Main->renderer->shading_mode = shading_mode;
-        OE_Main->renderer->unlockMutex();
-    }
+    OE_Main->renderer_info.shading_mode = shading_mode;
     OE_Main->renderer_mutex.unlockMutex();
     oe::restart_renderer();
 }
 
 oe::RENDERER_SHADING_MODE oe::get_shading_mode() {
     OE_API_Helpers::checkIfInit();
-    oe::RENDERER_SHADING_MODE output = oe::RENDERER_REGULAR_SHADING;
+    oe::RENDERER_SHADING_MODE output;
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->lockMutex();
-        output = OE_Main->renderer->shading_mode;
-        OE_Main->renderer->unlockMutex();
-    }
+    output = OE_Main->renderer_info.shading_mode;
     OE_Main->renderer_mutex.unlockMutex();
     return output;
 }
@@ -575,88 +582,64 @@ oe::RENDERER_SHADING_MODE oe::get_shading_mode() {
 void oe::render_wireframe(bool value) {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->use_wireframe = value;
-    }
+    OE_Main->renderer_info.use_wireframe = value;
     OE_Main->renderer_mutex.unlockMutex();
 }
 
 void oe::toggle_wireframe_rendering() {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->lockMutex();
-        if (OE_Main->renderer->use_wireframe)
-            OE_Main->renderer->use_wireframe = false;
-        else
-            OE_Main->renderer->use_wireframe = true;
-        OE_Main->renderer->unlockMutex();
-    }
+    if (OE_Main->renderer_info.use_wireframe)
+        OE_Main->renderer_info.use_wireframe = false;
+    else
+        OE_Main->renderer_info.use_wireframe = true;
     OE_Main->renderer_mutex.unlockMutex();
 }
 
 void oe::render_bounding_boxes(bool value) {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->render_bounding_boxes = value;
-    }
+    OE_Main->renderer_info.render_bounding_boxes = value;
     OE_Main->renderer_mutex.unlockMutex();
 }
 void oe::toggle_bounding_boxes_rendering() {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->lockMutex();
-        if (OE_Main->renderer->render_bounding_boxes)
-            OE_Main->renderer->render_bounding_boxes = false;
-        else
-            OE_Main->renderer->render_bounding_boxes = true;
-        OE_Main->renderer->unlockMutex();
-    }
+    if (OE_Main->renderer_info.render_bounding_boxes)
+        OE_Main->renderer_info.render_bounding_boxes = false;
+    else
+        OE_Main->renderer_info.render_bounding_boxes = true;
     OE_Main->renderer_mutex.unlockMutex();
 }
 
 void oe::render_bounding_spheres(bool value) {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->render_bounding_spheres = value;
-    }
+    OE_Main->renderer_info.render_bounding_spheres = value;
     OE_Main->renderer_mutex.unlockMutex();
 }
 void oe::toggle_bounding_spheres_rendering() {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->lockMutex();
-        if (OE_Main->renderer->render_bounding_spheres)
-            OE_Main->renderer->render_bounding_spheres = false;
-        else
-            OE_Main->renderer->render_bounding_spheres = true;
-        OE_Main->renderer->unlockMutex();
-    }
+    if (OE_Main->renderer_info.render_bounding_spheres)
+        OE_Main->renderer_info.render_bounding_spheres = false;
+    else
+        OE_Main->renderer_info.render_bounding_spheres = true;
     OE_Main->renderer_mutex.unlockMutex();
 }
 
 void oe::render_HDR(bool value) {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->use_HDR = value;
-    }
+    OE_Main->renderer_info.use_hdr = value;
     OE_Main->renderer_mutex.unlockMutex();
 }
 void oe::toggle_render_HDR() {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
-    if (OE_Main->renderer != nullptr) {
-        OE_Main->renderer->lockMutex();
-        if (OE_Main->renderer->use_HDR)
-            OE_Main->renderer->use_HDR = false;
-        else
-            OE_Main->renderer->use_HDR = true;
-        OE_Main->renderer->unlockMutex();
-    }
+    if (OE_Main->renderer_info.use_hdr)
+        OE_Main->renderer_info.use_hdr = false;
+    else
+        OE_Main->renderer_info.use_hdr = true;
     OE_Main->renderer_mutex.unlockMutex();
 }

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -652,6 +652,24 @@ void oe::toggle_render_HDR() {
     OE_Main->renderer_mutex.unlockMutex();
 }
 
+void oe::set_renderer_sanity_checks(bool value) {
+    OE_API_Helpers::checkIfInit();
+    OE_Main->renderer_mutex.lockMutex();
+    OE_Main->renderer_info.sanity_checks = value;
+    OE_Main->renderer_mutex.unlockMutex();
+}
+
+void oe::toggle_renderer_sanity_checks() {
+    OE_API_Helpers::checkIfInit();
+    OE_Main->renderer_mutex.lockMutex();
+    if (OE_Main->renderer_info.sanity_checks)
+        OE_Main->renderer_info.sanity_checks = false;
+    else
+        OE_Main->renderer_info.sanity_checks = true;
+    OE_Main->renderer_mutex.unlockMutex();
+}
+
+
 void oe::set_window_title(std::string title) {
     OE_API_Helpers::checkIfInit();
     OE_Main->window_mutex.lockMutex();

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -547,7 +547,7 @@ void oe::restart_renderer() {
     OE_Main->window_mutex.unlockMutex();
 }
 
-void oe::set_shading_mode(OE_RENDERER_SHADING_MODE shading_mode) {
+void oe::set_shading_mode(oe::RENDERER_SHADING_MODE shading_mode) {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex.lockMutex();
     if (OE_Main->renderer != nullptr) {
@@ -559,9 +559,9 @@ void oe::set_shading_mode(OE_RENDERER_SHADING_MODE shading_mode) {
     oe::restart_renderer();
 }
 
-OE_RENDERER_SHADING_MODE oe::get_shading_mode() {
+oe::RENDERER_SHADING_MODE oe::get_shading_mode() {
     OE_API_Helpers::checkIfInit();
-    OE_RENDERER_SHADING_MODE output = OE_RENDERER_REGULAR_SHADING;
+    oe::RENDERER_SHADING_MODE output = oe::RENDERER_REGULAR_SHADING;
     OE_Main->renderer_mutex.lockMutex();
     if (OE_Main->renderer != nullptr) {
         OE_Main->renderer->lockMutex();

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -112,7 +112,7 @@ bool oe::is_mouse_moved() {
 int oe::get_delta_mouse_x() {
     OE_API_Helpers::checkIfInit();
     OE_Main->window->event_handler.lockMutex();
-    int output = OE_MouseEvent::delta_x;
+    int output = OE_Main->window->event_handler.get_mouse_delta_x();
     OE_Main->window->event_handler.unlockMutex();
     return output;
 }
@@ -120,7 +120,7 @@ int oe::get_delta_mouse_x() {
 int oe::get_delta_mouse_y() {
     OE_API_Helpers::checkIfInit();
     OE_Main->window->event_handler.lockMutex();
-    int output = OE_MouseEvent::delta_y;
+    int output = OE_Main->window->event_handler.get_mouse_delta_y();
     OE_Main->window->event_handler.unlockMutex();
     return output;
 }
@@ -128,7 +128,7 @@ int oe::get_delta_mouse_y() {
 int oe::get_mouse_x() {
     OE_API_Helpers::checkIfInit();
     OE_Main->window->event_handler.lockMutex();
-    int output = OE_MouseEvent::x;
+    int output = OE_Main->window->event_handler.get_mouse_x();
     OE_Main->window->event_handler.unlockMutex();
     return output;
 }
@@ -136,14 +136,16 @@ int oe::get_mouse_x() {
 int oe::get_mouse_y() {
     OE_API_Helpers::checkIfInit();
     OE_Main->window->event_handler.lockMutex();
-    int output = OE_MouseEvent::y;
+    int output = OE_Main->window->event_handler.get_mouse_y();
     OE_Main->window->event_handler.unlockMutex();
     return output;
 }
 
 void oe::destroy_event(std::string name) {
     OE_API_Helpers::checkIfInit();
+    OE_Main->window->event_handler.lockMutex();
     OE_Main->window->event_handler.destroyIEvent(name);
+    OE_Main->window->event_handler.unlockMutex();
 }
 
 void oe::pause(int x) {

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -19,6 +19,14 @@ void oe::preinit::request_gles2() {
 #endif
 }
 
+void oe::preinit::request_gles31() {
+    // NOTE: Windows needs ANGLE to support OpenGL ES. For now let's use the other renderer
+    // ANGLE is not easy to install as a library and use
+#ifndef OE_PLATFORM_WINDOWS
+    oe::preinit::winsys_parameters.requested_backend = nre::gpu::GLES;
+#endif
+}
+
 size_t oe::init() {
     OE_Main = new OE_TaskManager();
     return OE_Main->Init("Oxygen Engine Test", 800, 600, false, preinit::renderer_parameters, preinit::winsys_parameters,

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -651,3 +651,36 @@ void oe::toggle_render_HDR() {
         OE_Main->renderer_info.use_hdr = true;
     OE_Main->renderer_mutex.unlockMutex();
 }
+
+void oe::set_window_title(std::string title) {
+    OE_API_Helpers::checkIfInit();
+    OE_Main->window_mutex.lockMutex();
+    OE_Main->window_info.title = title;
+    OE_Main->window_mutex.unlockMutex();
+}
+
+std::string oe::get_window_title() {
+    OE_API_Helpers::checkIfInit();
+    std::string output;
+    OE_Main->window_mutex.lockMutex();
+    output = OE_Main->window_info.title;
+    OE_Main->window_mutex.unlockMutex();
+    return output;
+}
+
+void oe::toggle_window_fullscreen() {
+    OE_API_Helpers::checkIfInit();
+    OE_Main->window_mutex.lockMutex();
+    if (OE_Main->window_info.use_fullscreen)
+        OE_Main->window_info.use_fullscreen = false;
+    else
+        OE_Main->window_info.use_fullscreen = true;
+    OE_Main->window_mutex.unlockMutex();
+}
+
+void oe::set_window_fullscreen(bool value) {
+    OE_API_Helpers::checkIfInit();
+    OE_Main->window_mutex.lockMutex();
+    OE_Main->window_info.use_fullscreen = value;
+    OE_Main->window_mutex.unlockMutex();
+}

--- a/src/dummy_classes.cpp
+++ b/src/dummy_classes.cpp
@@ -75,7 +75,7 @@ bool oe::physics_base_t::init(physics_init_info params) {
     return true;
 }
 
-void oe::physics_base_t::update_info(oe::physics_update_info params) {
+void oe::physics_base_t::update_info(oe::physics_update_info params) noexcept {
     // update the parameters in one place
 }
 
@@ -99,7 +99,6 @@ void oe::networking_base_t::init(networking_init_info params) {
 int oe::networking_base_t::execute(OE_Task) {
 
     // int a =0;
-
     while (!done) {
         // manage networking stuff, use your own threads etc.
         // YOU control the loop. Upon a call on this->destroy() it should stop though

--- a/src/dummy_classes.cpp
+++ b/src/dummy_classes.cpp
@@ -48,16 +48,16 @@ bool oe::renderer_base_t::init(oe::renderer_init_info init_info, oe::renderer_up
     return true;
 }
 
-bool oe::renderer_base_t::updateSingleThread(oe::renderer_update_info update_info, oe::winsys_output winsys_info) {
+bool oe::renderer_base_t::update_single_thread(oe::renderer_update_info update_info, oe::winsys_output winsys_info) {
     return true;
 }
 
-bool oe::renderer_base_t::updateData(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
-                                     bool has_renderer_restarted) {
+bool oe::renderer_base_t::update_data(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
+                                      bool has_renderer_restarted) {
     return true;
 }
 
-bool oe::renderer_base_t::updateMultiThread(OE_Task*, int) {
+bool oe::renderer_base_t::update_multi_thread(OE_Task*, int) {
     return true;
 }
 
@@ -79,7 +79,7 @@ void oe::physics_base_t::update_info(oe::physics_update_info params) {
     // update the parameters in one place
 }
 
-bool oe::physics_base_t::updateMultiThread(OE_Task* task, int thread_num) {
+bool oe::physics_base_t::update_multi_thread(OE_Task* task, int thread_num) {
     // throw 5;
     return true;
 }

--- a/src/dummy_classes.cpp
+++ b/src/dummy_classes.cpp
@@ -13,23 +13,23 @@ oe::winsys_base_t::winsys_base_t() {
 oe::winsys_base_t::~winsys_base_t() {
 }
 
-bool oe::winsys_base_t::init(int x, int y, string titlea, bool isFullscreen, bool use_legacy_renderer, void* data) {
-    return true;
+oe::winsys_output oe::winsys_base_t::init(oe::winsys_init_info init_info, oe::winsys_update_info update_info) {
+    return oe::winsys_output();
 }
 
-bool oe::winsys_base_t::getMouseLockedState() {
-    return mouse_locked;
+bool oe::winsys_base_t::is_mouse_locked() {
+    return false;
 }
-void oe::winsys_base_t::lockMouse() {
+void oe::winsys_base_t::lock_mouse() {
 }
-void oe::winsys_base_t::unlockMouse() {
-}
-
-bool oe::winsys_base_t::update() {
-    return true;
+void oe::winsys_base_t::unlock_mouse() {
 }
 
-bool oe::winsys_base_t::updateEvents() {
+oe::winsys_output oe::winsys_base_t::update(oe::winsys_update_info update_info) {
+    return oe::winsys_output();
+}
+
+bool oe::winsys_base_t::update_events() {
     return true;
 }
 
@@ -43,15 +43,17 @@ oe::renderer_base_t::renderer_base_t() {
 oe::renderer_base_t::~renderer_base_t() {
 }
 
-bool oe::renderer_base_t::init() {
+bool oe::renderer_base_t::init(oe::renderer_init_info init_info, oe::renderer_update_info update_info,
+                               oe::winsys_output winsys_info) {
     return true;
 }
 
-bool oe::renderer_base_t::updateSingleThread() {
+bool oe::renderer_base_t::updateSingleThread(oe::renderer_update_info update_info, oe::winsys_output winsys_info) {
     return true;
 }
 
-bool oe::renderer_base_t::updateData() {
+bool oe::renderer_base_t::updateData(oe::renderer_update_info update_info, oe::winsys_output winsys_info,
+                                     bool has_renderer_restarted) {
     return true;
 }
 
@@ -69,8 +71,12 @@ oe::physics_base_t::physics_base_t() {
 oe::physics_base_t::~physics_base_t() {
 }
 
-bool oe::physics_base_t::init() {
+bool oe::physics_base_t::init(physics_init_info params) {
     return true;
+}
+
+void oe::physics_base_t::update_info(oe::physics_update_info params) {
+    // update the parameters in one place
 }
 
 bool oe::physics_base_t::updateMultiThread(OE_Task* task, int thread_num) {
@@ -87,7 +93,7 @@ oe::networking_base_t::networking_base_t() {
 oe::networking_base_t::~networking_base_t() {
 }
 
-void oe::networking_base_t::init() {
+void oe::networking_base_t::init(networking_init_info params) {
 }
 
 int oe::networking_base_t::execute(OE_Task) {

--- a/src/dummy_classes.cpp
+++ b/src/dummy_classes.cpp
@@ -7,90 +7,90 @@
 
 using namespace std;
 
-OE_WindowSystemBase::OE_WindowSystemBase() {
+oe::winsys_base_t::winsys_base_t() {
 }
 
-OE_WindowSystemBase::~OE_WindowSystemBase() {
+oe::winsys_base_t::~winsys_base_t() {
 }
 
-bool OE_WindowSystemBase::init(int x, int y, string titlea, bool isFullscreen, bool use_legacy_renderer, void* data) {
+bool oe::winsys_base_t::init(int x, int y, string titlea, bool isFullscreen, bool use_legacy_renderer, void* data) {
     return true;
 }
 
-bool OE_WindowSystemBase::getMouseLockedState() {
+bool oe::winsys_base_t::getMouseLockedState() {
     return mouse_locked;
 }
-void OE_WindowSystemBase::lockMouse() {
+void oe::winsys_base_t::lockMouse() {
 }
-void OE_WindowSystemBase::unlockMouse() {
+void oe::winsys_base_t::unlockMouse() {
 }
 
-bool OE_WindowSystemBase::update() {
+bool oe::winsys_base_t::update() {
     return true;
 }
 
-bool OE_WindowSystemBase::updateEvents() {
+bool oe::winsys_base_t::updateEvents() {
     return true;
 }
 
-void OE_WindowSystemBase::destroy() {
+void oe::winsys_base_t::destroy() {
 }
 
 
-OE_RendererBase::OE_RendererBase() {
+oe::renderer_base_t::renderer_base_t() {
 }
 
-OE_RendererBase::~OE_RendererBase() {
+oe::renderer_base_t::~renderer_base_t() {
 }
 
-bool OE_RendererBase::init() {
+bool oe::renderer_base_t::init() {
     return true;
 }
 
-bool OE_RendererBase::updateSingleThread() {
+bool oe::renderer_base_t::updateSingleThread() {
     return true;
 }
 
-bool OE_RendererBase::updateData() {
+bool oe::renderer_base_t::updateData() {
     return true;
 }
 
-bool OE_RendererBase::updateMultiThread(OE_Task*, int) {
+bool oe::renderer_base_t::updateMultiThread(OE_Task*, int) {
     return true;
 }
 
-void OE_RendererBase::destroy() {
+void oe::renderer_base_t::destroy() {
 }
 
 
-OE_PhysicsEngineBase::OE_PhysicsEngineBase() {
+oe::physics_base_t::physics_base_t() {
 }
 
-OE_PhysicsEngineBase::~OE_PhysicsEngineBase() {
+oe::physics_base_t::~physics_base_t() {
 }
 
-bool OE_PhysicsEngineBase::init() {
+bool oe::physics_base_t::init() {
     return true;
 }
 
-bool OE_PhysicsEngineBase::updateMultiThread(OE_Task* task, int thread_num) {
+bool oe::physics_base_t::updateMultiThread(OE_Task* task, int thread_num) {
     // throw 5;
     return true;
 }
 
-void OE_PhysicsEngineBase::destroy() {
+void oe::physics_base_t::destroy() {
     return;
 }
 
-OE_NetworkingBase::OE_NetworkingBase() {
+oe::networking_base_t::networking_base_t() {
 }
-OE_NetworkingBase::~OE_NetworkingBase() {
-}
-
-void OE_NetworkingBase::init() {
+oe::networking_base_t::~networking_base_t() {
 }
 
-int OE_NetworkingBase::execute(OE_Task) {
+void oe::networking_base_t::init() {
+}
+
+int oe::networking_base_t::execute(OE_Task) {
 
     // int a =0;
 
@@ -103,6 +103,6 @@ int OE_NetworkingBase::execute(OE_Task) {
     }
     return 0;
 }
-void OE_NetworkingBase::destroy() {
+void oe::networking_base_t::destroy() {
     done = true;
 }

--- a/src/error_oe.cpp
+++ b/src/error_oe.cpp
@@ -142,11 +142,12 @@ int OE_TaskManager::tryRun_task(const std::string& name, OE_Task& task) {
     return output;
 }
 
-void OE_TaskManager::tryRun_physics_updateMultiThread(const std::string& name, const int& comp_threads_copy) {
+bool OE_TaskManager::tryRun_physics_updateMultiThread(const std::string& name, const int& comp_threads_copy) {
 
 
     try {
-        this->physics->updateMultiThread(&this->threads[name].physics_task, comp_threads_copy);
+        this->physics->update_multi_thread(&this->threads[name].physics_task, comp_threads_copy);
+        return false;
     } catch (oe::api_error& e) {
         std::string error_str = "[OE Error] " + e.name_ + " thrown in updateMultiThread in thread: '" + name +
                                 "', thread_num: " + std::to_string(comp_threads_copy);
@@ -178,6 +179,7 @@ void OE_TaskManager::tryRun_physics_updateMultiThread(const std::string& name, c
         cout << outputa << endl;
         OE_WriteToLog(outputa + "\n");
     }
+    return true;
 }
 
 bool OE_TaskManager::tryRun_renderer_updateSingleThread() {
@@ -187,7 +189,8 @@ bool OE_TaskManager::tryRun_renderer_updateSingleThread() {
     this->renderer_mutex.unlockMutex();
 
     try {
-        return this->renderer->updateSingleThread(renderer_info_copy, this->window_output);
+        this->renderer->update_single_thread(renderer_info_copy, this->window_output);
+        return false;
     } catch (oe::api_error& e) {
         std::string error_str =
             "[NRE Error] " + e.name_ + " thrown in updateSingleThread, invocation: " + std::to_string(this->countar);
@@ -212,17 +215,18 @@ bool OE_TaskManager::tryRun_renderer_updateSingleThread() {
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
-    return false;
+    return true;
 }
 
-void OE_TaskManager::tryRun_renderer_updateData() {
+bool OE_TaskManager::tryRun_renderer_updateData() {
 
     this->renderer_mutex.lockMutex();
     auto renderer_info_copy = this->renderer_info;
     this->renderer_mutex.unlockMutex();
 
     try {
-        this->renderer->updateData(renderer_info_copy, this->window_output, this->restart_renderer);
+        this->renderer->update_data(renderer_info_copy, this->window_output, this->restart_renderer);
+        return false;
     } catch (oe::api_error& e) {
         std::string error_str =
             "[NRE Error] " + e.name_ + " thrown in updateData, invocation: " + std::to_string(this->countar);
@@ -247,6 +251,7 @@ void OE_TaskManager::tryRun_renderer_updateData() {
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
+    return true;
 }
 
 bool OE_TaskManager::tryRun_winsys_update() {
@@ -280,7 +285,7 @@ bool OE_TaskManager::tryRun_winsys_update() {
     return true;
 }
 
-void OE_TaskManager::tryRun_winsys_init(int x, int y, std::string titlea, bool fullscreen, oe::winsys_init_info params) {
+bool OE_TaskManager::tryRun_winsys_init(int x, int y, std::string titlea, bool fullscreen, oe::winsys_init_info params) {
 
     this->window_init_info           = params;
     this->window_info.res_x          = x;
@@ -290,6 +295,7 @@ void OE_TaskManager::tryRun_winsys_init(int x, int y, std::string titlea, bool f
 
     try {
         this->window_output = this->window->init(this->window_init_info, this->window_info);
+        return false;
     } catch (oe::winsys_error& e) {
         std::string error_str = "[OE WINSYS Error] " + e.name_ + " thrown in window system initialization";
         error_str += "\n\t" + e.what();
@@ -306,13 +312,15 @@ void OE_TaskManager::tryRun_winsys_init(int x, int y, std::string titlea, bool f
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
+    return true;
 }
 
-void OE_TaskManager::tryRun_physics_init(oe::physics_init_info params) {
+bool OE_TaskManager::tryRun_physics_init(oe::physics_init_info params) {
 
     try {
         this->physics_init_info = params;
         this->physics->init(params);
+        return false;
     } catch (oe::physics_error& e) {
         std::string error_str = "[OE Error] " + e.name_ + " thrown in physics engine initialization";
         error_str += "\n\t" + e.what();
@@ -328,13 +336,15 @@ void OE_TaskManager::tryRun_physics_init(oe::physics_init_info params) {
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
+    return true;
 }
 
-void OE_TaskManager::tryRun_renderer_init(oe::renderer_init_info params) {
+bool OE_TaskManager::tryRun_renderer_init(oe::renderer_init_info params) {
 
     try {
         this->renderer_init_info = params;
         this->renderer->init(this->renderer_init_info, this->renderer_info, this->window_output);
+        return false;
     } catch (oe::renderer_error& e) {
         std::string error_str = "[NRE Error] " + e.name_ + " thrown in renderer initialization";
         error_str += "\n\t" + e.what();
@@ -350,12 +360,14 @@ void OE_TaskManager::tryRun_renderer_init(oe::renderer_init_info params) {
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
+    return true;
 }
 
-void OE_TaskManager::tryRun_network_init(oe::networking_init_info params) {
+bool OE_TaskManager::tryRun_network_init(oe::networking_init_info params) {
     try {
         this->network_init_info = params;
         this->network->init(params);
+        return false;
     } catch (oe::networking_error& e) {
         std::string error_str = "[SLC Error] " + e.name_ + " thrown in networking initialization";
         error_str += "\n\t" + e.what();
@@ -371,4 +383,5 @@ void OE_TaskManager::tryRun_network_init(oe::networking_init_info params) {
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
+    return true;
 }

--- a/src/error_oe.cpp
+++ b/src/error_oe.cpp
@@ -149,22 +149,22 @@ bool OE_TaskManager::tryRun_physics_updateMultiThread(const std::string& name, c
         this->physics->update_multi_thread(&this->threads[name].physics_task, comp_threads_copy);
         return false;
     } catch (oe::api_error& e) {
-        std::string error_str = "[OE Error] " + e.name_ + " thrown in updateMultiThread in thread: '" + name +
+        std::string error_str = "[HPE Error] " + e.name_ + " thrown in update_multi_thread in thread: '" + name +
                                 "', thread_num: " + std::to_string(comp_threads_copy);
         error_str += ", invocation: " + std::to_string(this->threads[name].physics_task.counter) + "\n";
         error_str += "\t" + e.what() + "\n";
         cout << error_str;
         OE_WriteToLog(error_str);
     } catch (oe::physics_error& e) {
-        std::string error_str = "[OE Error] " + e.name_ + " thrown in updateMultiThread in thread: '" + name +
+        std::string error_str = "[HPE Error] " + e.name_ + " thrown in update_multi_thread in thread: '" + name +
                                 "', thread_num: " + std::to_string(comp_threads_copy);
         error_str += ", invocation: " + std::to_string(this->threads[name].physics_task.counter) + "\n";
         error_str += "\t" + e.what() + "\n";
         cout << error_str;
         OE_WriteToLog(error_str);
     } catch (std::exception& e) {
-        std::string error_str = "[OE Error] " + string(typeid(e).name()) + " thrown in updateMultiThread in thread: '" + name +
-                                "', thread_num: " + std::to_string(comp_threads_copy);
+        std::string error_str = "[HPE Error] " + string(typeid(e).name()) + " thrown in update_multi_thread in thread: '" +
+                                name + "', thread_num: " + std::to_string(comp_threads_copy);
         error_str += ", invocation: " + std::to_string(this->threads[name].physics_task.counter) + "\n";
         error_str += "\t" + string(e.what()) + "\n";
         cout << error_str;
@@ -173,7 +173,7 @@ bool OE_TaskManager::tryRun_physics_updateMultiThread(const std::string& name, c
         /// universal error handling. will catch any exception
         /// feel free to add specific handling for specific errors
         auto   task    = this->threads[name].physics_task;
-        string outputa = string("[OE Error] Physics exception thrown in updateMultiThread in thread: '" + name +
+        string outputa = string("[HPE Error] Physics exception thrown in update_multi_thread in thread: '" + name +
                                 "', thread_num: " + std::to_string(comp_threads_copy));
         outputa += ", invocation: " + std::to_string(task.counter);
         cout << outputa << endl;
@@ -193,25 +193,25 @@ bool OE_TaskManager::tryRun_renderer_updateSingleThread() {
         return false;
     } catch (oe::api_error& e) {
         std::string error_str =
-            "[NRE Error] " + e.name_ + " thrown in updateSingleThread, invocation: " + std::to_string(this->countar);
+            "[NRE Error] " + e.name_ + " thrown in update_single_thread, invocation: " + std::to_string(this->countar);
         error_str += "\n\t" + e.what();
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (oe::renderer_error& e) {
         std::string error_str =
-            "[NRE Error] " + e.name_ + " thrown in updateSingleThread, invocation: " + std::to_string(this->countar);
+            "[NRE Error] " + e.name_ + " thrown in update_single_thread, invocation: " + std::to_string(this->countar);
         error_str += "\n\t" + e.what();
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (std::exception& e) {
         std::string error_str = "[NRE Error] " + string(typeid(e).name()) +
-                                " thrown in updateSingleThread, invocation: " + std::to_string(this->countar);
+                                " thrown in update_single_thread, invocation: " + std::to_string(this->countar);
         error_str += "\n\t" + string(e.what());
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (...) {
         std::string error_str =
-            "[NRE Error] Renderer exception thrown in updateSingleThread, invocation: " + std::to_string(this->countar);
+            "[NRE Error] Renderer exception thrown in update_single_thread, invocation: " + std::to_string(this->countar);
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
@@ -229,25 +229,25 @@ bool OE_TaskManager::tryRun_renderer_updateData() {
         return false;
     } catch (oe::api_error& e) {
         std::string error_str =
-            "[NRE Error] " + e.name_ + " thrown in updateData, invocation: " + std::to_string(this->countar);
+            "[NRE Error] " + e.name_ + " thrown in update_data, invocation: " + std::to_string(this->countar);
         error_str += "\n\t" + e.what();
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (oe::renderer_error& e) {
         std::string error_str =
-            "[NRE Error] " + e.name_ + " thrown in updateData, invocation: " + std::to_string(this->countar);
+            "[NRE Error] " + e.name_ + " thrown in update_data, invocation: " + std::to_string(this->countar);
         error_str += "\n\t" + e.what();
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (std::exception& e) {
         std::string error_str =
-            "[NRE Error] " + string(typeid(e).name()) + " thrown in updateData, invocation: " + std::to_string(this->countar);
+            "[NRE Error] " + string(typeid(e).name()) + " thrown in update_data, invocation: " + std::to_string(this->countar);
         error_str += "\n\t" + string(e.what());
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (...) {
         std::string error_str =
-            "[NRE Error] Renderer exception thrown in updateData, invocation: " + std::to_string(this->countar);
+            "[NRE Error] Renderer exception thrown in update_data, invocation: " + std::to_string(this->countar);
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
@@ -277,7 +277,7 @@ bool OE_TaskManager::tryRun_winsys_update() {
         OE_WriteToLog(error_str + "\n");
     } catch (...) {
         std::string error_str =
-            "[OE WINSYS Error] Exception thrown in winsys update, invocation: " + std::to_string(this->countar);
+            "[OE WINSYS Error] Exception thrown in winsys->update(), invocation: " + std::to_string(this->countar);
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
@@ -322,17 +322,17 @@ bool OE_TaskManager::tryRun_physics_init(oe::physics_init_info params) {
         this->physics->init(params);
         return false;
     } catch (oe::physics_error& e) {
-        std::string error_str = "[OE Error] " + e.name_ + " thrown in physics engine initialization";
+        std::string error_str = "[HPE Error] " + e.name_ + " thrown in physics engine initialization";
         error_str += "\n\t" + e.what();
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (std::exception& e) {
-        std::string error_str = "[OE Error] " + string(typeid(e).name()) + " thrown in physics engine initialization";
+        std::string error_str = "[HPE Error] " + string(typeid(e).name()) + " thrown in physics engine initialization";
         error_str += "\n\t" + string(e.what());
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     } catch (...) {
-        std::string error_str = "[OE Error] Could not initialize physics engine due to thrown exception in physics->init()";
+        std::string error_str = "[HPE Error] Could not initialize physics engine due to thrown exception in physics->init()";
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }

--- a/src/error_oe.cpp
+++ b/src/error_oe.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 
 // This is where events' error handling is happening
-int OE_Event::internal_call() {
+int oe::event_t::internal_call() {
     /***************************/
     /// generic handling
 

--- a/src/error_oe.cpp
+++ b/src/error_oe.cpp
@@ -144,6 +144,7 @@ int OE_TaskManager::tryRun_task(const std::string& name, OE_Task& task) {
 
 void OE_TaskManager::tryRun_physics_updateMultiThread(const std::string& name, const int& comp_threads_copy) {
 
+
     try {
         this->physics->updateMultiThread(&this->threads[name].physics_task, comp_threads_copy);
     } catch (oe::api_error& e) {
@@ -181,10 +182,12 @@ void OE_TaskManager::tryRun_physics_updateMultiThread(const std::string& name, c
 
 bool OE_TaskManager::tryRun_renderer_updateSingleThread() {
 
-    bool output = false;
+    this->renderer_mutex.lockMutex();
+    auto renderer_info_copy = this->renderer_info;
+    this->renderer_mutex.unlockMutex();
 
     try {
-        output = this->renderer->updateSingleThread();
+        return this->renderer->updateSingleThread(renderer_info_copy, this->window_output);
     } catch (oe::api_error& e) {
         std::string error_str =
             "[NRE Error] " + e.name_ + " thrown in updateSingleThread, invocation: " + std::to_string(this->countar);
@@ -209,13 +212,17 @@ bool OE_TaskManager::tryRun_renderer_updateSingleThread() {
         cout << error_str << endl;
         OE_WriteToLog(error_str + "\n");
     }
-    return output;
+    return false;
 }
 
 void OE_TaskManager::tryRun_renderer_updateData() {
 
+    this->renderer_mutex.lockMutex();
+    auto renderer_info_copy = this->renderer_info;
+    this->renderer_mutex.unlockMutex();
+
     try {
-        this->renderer->updateData();
+        this->renderer->updateData(renderer_info_copy, this->window_output, this->restart_renderer);
     } catch (oe::api_error& e) {
         std::string error_str =
             "[NRE Error] " + e.name_ + " thrown in updateData, invocation: " + std::to_string(this->countar);
@@ -244,9 +251,13 @@ void OE_TaskManager::tryRun_renderer_updateData() {
 
 bool OE_TaskManager::tryRun_winsys_update() {
 
-    bool output = true;
+    this->window_mutex.lockMutex();
+    auto winsys_info = this->window_info;
+    this->window_mutex.unlockMutex();
+
     try {
-        output = this->window->update();
+        this->window_output = this->window->update(winsys_info);
+        return this->window_output.done;
     } catch (oe::winsys_error& e) {
         std::string error_str =
             "[OE WINSYS Error] " + e.name_ + " thrown in winsys update, invocation: " + std::to_string(this->countar);
@@ -266,14 +277,19 @@ bool OE_TaskManager::tryRun_winsys_update() {
         OE_WriteToLog(error_str + "\n");
     }
 
-    return output;
+    return true;
 }
 
-void OE_TaskManager::tryRun_winsys_init(int x, int y, std::string titlea, bool fullscreen, bool use_legacy_renderer,
-                                        void* params) {
+void OE_TaskManager::tryRun_winsys_init(int x, int y, std::string titlea, bool fullscreen, oe::winsys_init_info params) {
+
+    this->window_init_info           = params;
+    this->window_info.res_x          = x;
+    this->window_info.res_y          = y;
+    this->window_info.use_fullscreen = fullscreen;
+    this->window_info.title          = titlea;
 
     try {
-        this->window->init(x, y, titlea, fullscreen, use_legacy_renderer, params);
+        this->window_output = this->window->init(this->window_init_info, this->window_info);
     } catch (oe::winsys_error& e) {
         std::string error_str = "[OE WINSYS Error] " + e.name_ + " thrown in window system initialization";
         error_str += "\n\t" + e.what();
@@ -292,10 +308,11 @@ void OE_TaskManager::tryRun_winsys_init(int x, int y, std::string titlea, bool f
     }
 }
 
-void OE_TaskManager::tryRun_physics_init() {
+void OE_TaskManager::tryRun_physics_init(oe::physics_init_info params) {
 
     try {
-        this->physics->init();
+        this->physics_init_info = params;
+        this->physics->init(params);
     } catch (oe::physics_error& e) {
         std::string error_str = "[OE Error] " + e.name_ + " thrown in physics engine initialization";
         error_str += "\n\t" + e.what();
@@ -313,10 +330,11 @@ void OE_TaskManager::tryRun_physics_init() {
     }
 }
 
-void OE_TaskManager::tryRun_renderer_init() {
+void OE_TaskManager::tryRun_renderer_init(oe::renderer_init_info params) {
 
     try {
-        this->renderer->init();
+        this->renderer_init_info = params;
+        this->renderer->init(this->renderer_init_info, this->renderer_info, this->window_output);
     } catch (oe::renderer_error& e) {
         std::string error_str = "[NRE Error] " + e.name_ + " thrown in renderer initialization";
         error_str += "\n\t" + e.what();
@@ -334,9 +352,10 @@ void OE_TaskManager::tryRun_renderer_init() {
     }
 }
 
-void OE_TaskManager::tryRun_network_init() {
+void OE_TaskManager::tryRun_network_init(oe::networking_init_info params) {
     try {
-        this->network->init();
+        this->network_init_info = params;
+        this->network->init(params);
     } catch (oe::networking_error& e) {
         std::string error_str = "[SLC Error] " + e.name_ + " thrown in networking initialization";
         error_str += "\n\t" + e.what();

--- a/src/task_manager.cpp
+++ b/src/task_manager.cpp
@@ -281,7 +281,7 @@ void OE_TaskManager::Step() {
 
     this->updateWorld();
     // cout << "overcome critical part" << endl;
-    this->window->event_handler.handleAllEvents();
+    this->window->event_handler_.handle_all_events();
 
     this->syncBeginFrame();
 
@@ -340,7 +340,7 @@ void OE_TaskManager::Destroy() {
     this->renderer->destroy();
     this->physics->destroy();
 
-    this->window->event_handler.cleanup();
+    this->window->event_handler_.cleanup();
     this->window->destroy();
 
     delete this->renderer;

--- a/src/task_manager.cpp
+++ b/src/task_manager.cpp
@@ -133,7 +133,12 @@ int OE_TaskManager::Init(std::string titlea, int x, int y, bool fullscreen, oe::
         this->renderer = new NRE_RendererLegacy();
     else
         this->renderer = new NRE_Renderer();
-    this->renderer_init_errors = this->tryRun_renderer_init(renderer_init_info_in);
+
+    // do NOT try to initialise the renderer if the window system is borked
+    if (not this->winsys_init_errors)
+        this->renderer_init_errors = this->tryRun_renderer_init(renderer_init_info_in);
+    else
+        this->renderer_init_errors = true;
     this->renderer_mutex.unlockMutex();
 
     this->physics_mutex.lockMutex();

--- a/src/task_manager.cpp
+++ b/src/task_manager.cpp
@@ -145,11 +145,11 @@ int OE_TaskManager::Init(std::string titlea, int x, int y, bool fullscreen, bool
     this->renderer_mutex.unlockMutex();
 
     this->physics_mutex.lockMutex();
-    this->physics = new OE_PhysicsEngineBase();
+    this->physics = new oe::physics_base_t();
     this->tryRun_physics_init();
     this->physics_mutex.unlockMutex();
 
-    this->network = new OE_NetworkingBase();
+    this->network = new oe::networking_base_t();
     this->tryRun_network_init();
 
     this->createCondition();
@@ -165,7 +165,7 @@ int OE_TaskManager::Init(std::string titlea, int x, int y, bool fullscreen, bool
 #ifdef OE_PLATFORM_WEB
 
 #endif
-    oe::create_unsync_thread_method("network", &OE_NetworkingBase::execute, this->network);
+    oe::create_unsync_thread_method("network", &oe::networking_base_t::execute, this->network);
 
 #ifdef OE_PLATFORM_WEB
     oe_threads_ready_to_start = true;

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -52,9 +52,10 @@ oe::winsys_output OE_SDL_WindowSystem::init(oe::winsys_init_info init_info, oe::
 
 #ifndef OE_PLATFORM_WEB
     if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
-        cout << "OE ERROR: Could not initialize SDL2, " << SDL_GetError() << endl;
+        std::stringstream ss;
+        ss << "Could not initialize SDL2, " << SDL_GetError();
+        throw oe::winsys_init_failed(ss.str());
     }
-
 
     SDL_GL_LoadLibrary(NULL);
 

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -6,15 +6,18 @@
 using namespace std;
 
 OE_SDL_WindowSystem::OE_SDL_WindowSystem() {
-    this->winsys = OE_SDL;
+    this->winsys = oe::WINSYS_SDL;
 #ifdef OE_PLATFORM_LINUX
-    this->os = OE_LINUX;
+    this->os = oe::OS_LINUX;
 #endif
 #ifdef OE_PLATFORM_WINDOWS
-    this->os = OE_WINDOWS;
+    this->os = oe::OS_WINDOWS;
 #endif
 #ifdef OE_PLATFORM_ANDROID
-    this->os = OE_ANDROID;
+    this->os = oe::OS_ANDROID;
+#endif
+#ifdef OE_PLATFORM_WEB
+    this->os = oe::OS_WEB
 #endif
 }
 

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -275,19 +275,17 @@ bool OE_SDL_WindowSystem::updateEvents() {
     switch (this->event.type) {
     // check for key presses
     case SDL_KEYDOWN:
-        for (auto key : this->event_handler_.input_handler_.keyList_) {
-            if (this->event.key.keysym.sym == key.first) {
-                this->event_handler_.internal_register_keydown_event("keyboard-" + key.second);
-            }
+        if (this->event_handler_.input_handler_.keyList_.count(this->event.key.keysym.sym) != 0) {
+            auto key_string = this->event_handler_.input_handler_.keyList_[this->event.key.keysym.sym];
+            this->event_handler_.internal_register_keydown_event("keyboard-" + key_string);
         }
         break;
 
     // check for releases
     case SDL_KEYUP:
-        for (auto key : this->event_handler_.input_handler_.keyList_) {
-            if (this->event.key.keysym.sym == key.first) {
-                this->event_handler_.internal_register_keyup_event("keyboard-" + key.second);
-            }
+        if (this->event_handler_.input_handler_.keyList_.count(this->event.key.keysym.sym) != 0) {
+            auto key_string = this->event_handler_.input_handler_.keyList_[this->event.key.keysym.sym];
+            this->event_handler_.internal_register_keyup_event("keyboard-" + key_string);
         }
         break;
 
@@ -299,19 +297,17 @@ bool OE_SDL_WindowSystem::updateEvents() {
 
         // update mouse down events
     case SDL_MOUSEBUTTONDOWN:
-        for (auto key : this->event_handler_.input_handler_.mouseList_) {
-            if (this->event.button.button == key.first) {
-                this->event_handler_.internal_register_keydown_event("mouse-" + key.second);
-            }
+        if (this->event_handler_.input_handler_.mouseList_.count(this->event.button.button) != 0) {
+            auto key_string = this->event_handler_.input_handler_.mouseList_[this->event.button.button];
+            this->event_handler_.internal_register_keydown_event("mouse-" + key_string);
         }
         break;
 
     // update mouse up events
     case SDL_MOUSEBUTTONUP:
-        for (auto key : this->event_handler_.input_handler_.mouseList_) {
-            if (this->event.button.button == key.first) {
-                this->event_handler_.internal_register_keyup_event("mouse-" + key.second);
-            }
+        if (this->event_handler_.input_handler_.mouseList_.count(this->event.button.button) != 0) {
+            auto key_string = this->event_handler_.input_handler_.mouseList_[this->event.button.button];
+            this->event_handler_.internal_register_keyup_event("mouse-" + key_string);
         }
         break;
 

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -255,9 +255,14 @@ bool OE_SDL_WindowSystem::update() {
     if (this->mouse_moved) {
         // fetch mouse position, since this IS needed
         this->event_handler.lockMutex();
-        SDL_GetMouseState(&OE_MouseEvent::x, &OE_MouseEvent::y);
-        SDL_GetRelativeMouseState(&OE_MouseEvent::delta_x, &OE_MouseEvent::delta_y);
+
+        int mouse_x, mouse_y, mouse_delta_x, mouse_delta_y;
+        SDL_GetMouseState(&mouse_x, &mouse_y);
+        SDL_GetRelativeMouseState(&mouse_delta_x, &mouse_delta_y);
+        this->event_handler.internal_update_mouse_status(mouse_x, mouse_y, mouse_delta_x, mouse_delta_y);
+
         this->event_handler.unlockMutex();
+
         this->event_handler.broadcastIEvent("mouse-motion");
     }
 
@@ -296,12 +301,6 @@ bool OE_SDL_WindowSystem::updateEvents() {
     case SDL_MOUSEBUTTONDOWN:
         for (auto key : this->event_handler.input_handler.mouseList) {
             if (this->event.button.button == key.first) {
-                // fetch mouse position, since this may be needed
-                this->event_handler.lockMutex();
-                SDL_GetMouseState(&OE_MouseEvent::x, &OE_MouseEvent::y);
-                SDL_GetRelativeMouseState(&OE_MouseEvent::delta_x, &OE_MouseEvent::delta_y);
-                this->event_handler.unlockMutex();
-
                 this->event_handler.internalBroadcastKeyDownEvent("mouse-" + key.second);
             }
         }
@@ -311,12 +310,6 @@ bool OE_SDL_WindowSystem::updateEvents() {
     case SDL_MOUSEBUTTONUP:
         for (auto key : this->event_handler.input_handler.mouseList) {
             if (this->event.button.button == key.first) {
-                // fetch mouse position, since this may be needed
-                this->event_handler.lockMutex();
-                SDL_GetMouseState(&OE_MouseEvent::x, &OE_MouseEvent::y);
-                SDL_GetRelativeMouseState(&OE_MouseEvent::delta_x, &OE_MouseEvent::delta_y);
-                this->event_handler.unlockMutex();
-
                 this->event_handler.internalBroadcastKeyUpEvent("mouse-" + key.second);
             }
         }
@@ -326,10 +319,8 @@ bool OE_SDL_WindowSystem::updateEvents() {
     case SDL_MOUSEWHEEL:
 
         this->event_handler.lockMutex();
-        OE_MouseEvent::mouse_wheel = event.wheel.y;
+        //mouse_mouse_wheel = event.wheel.y;
         // fetch mouse position, since this may be needed
-        SDL_GetMouseState(&OE_MouseEvent::x, &OE_MouseEvent::y);
-        SDL_GetRelativeMouseState(&OE_MouseEvent::delta_x, &OE_MouseEvent::delta_y);
         this->event_handler.unlockMutex();
 
         this->event_handler.broadcastIEvent("mouse-wheel");

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -319,8 +319,8 @@ bool OE_SDL_WindowSystem::updateEvents() {
     case SDL_MOUSEWHEEL:
 
         this->event_handler.lockMutex();
-        //mouse_mouse_wheel = event.wheel.y;
-        // fetch mouse position, since this may be needed
+        // mouse_mouse_wheel = event.wheel.y;
+        //  fetch mouse position, since this may be needed
         this->event_handler.unlockMutex();
 
         this->event_handler.broadcastIEvent("mouse-wheel");

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -87,16 +87,17 @@ oe::winsys_output OE_SDL_WindowSystem::init(oe::winsys_init_info init_info, oe::
     if (not use_legacy_renderer) {
 
 #ifndef OE_PLATFORM_WEB
-        this->context = SDL_GL_CreateContext(this->window);
-        if (context == NULL) {
-            cout << "OE WARNING: Could not initialize OpenGL 3.3 Core Context, " << SDL_GetError() << endl;
-            SDL_DestroyWindow(window);
-            this->createWindow(x, y);
+        if (init_info.requested_backend == nre::gpu::GL) {
+            this->context = SDL_GL_CreateContext(this->window);
+            if (context == NULL) {
+                cout << "OE WARNING: Could not initialize OpenGL 3.3 Core Context, " << SDL_GetError() << endl;
+                SDL_DestroyWindow(window);
+                this->createWindow(x, y);
+            }
+            else {
+                return this->finishInit();
+            }
         }
-        else {
-            return this->finishInit();
-        }
-
 #endif
         // Request an OpenGL ES 3.0 context
 

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -198,7 +198,7 @@ void OE_SDL_WindowSystem::finishInit() {
         }
     }
 
-    this->event_handler.init();
+    this->event_handler_.init();
 }
 
 bool OE_SDL_WindowSystem::getMouseLockedState() {
@@ -238,15 +238,15 @@ bool OE_SDL_WindowSystem::update() {
     this->resolution_y = y;
     unlockMutex();
 
-    this->event_handler.updateInput();
+    this->event_handler_.update_input();
     this->mouse_moved = false;
 
     while (SDL_PollEvent(&this->event)) {
 
         // exit before handling SDL events
         if (event.type == SDL_QUIT) {
-            this->event_handler.done = true;
-            return this->event_handler.done;
+            this->event_handler_.done_ = true;
+            return this->event_handler_.done_;
         }
         this->updateEvents();
         this->updateWindowEvents();
@@ -254,20 +254,20 @@ bool OE_SDL_WindowSystem::update() {
 
     if (this->mouse_moved) {
         // fetch mouse position, since this IS needed
-        this->event_handler.lockMutex();
+        this->event_handler_.lockMutex();
 
         int mouse_x, mouse_y, mouse_delta_x, mouse_delta_y;
         SDL_GetMouseState(&mouse_x, &mouse_y);
         SDL_GetRelativeMouseState(&mouse_delta_x, &mouse_delta_y);
-        this->event_handler.internal_update_mouse_status(mouse_x, mouse_y, mouse_delta_x, mouse_delta_y);
+        this->event_handler_.internal_update_mouse_status(mouse_x, mouse_y, mouse_delta_x, mouse_delta_y);
 
-        this->event_handler.unlockMutex();
+        this->event_handler_.unlockMutex();
 
-        this->event_handler.broadcastIEvent("mouse-motion");
+        this->event_handler_.broadcast_ievent("mouse-motion");
     }
 
     // This is needed to support things like OE_Finish()
-    return this->event_handler.done;
+    return this->event_handler_.done_;
 }
 
 bool OE_SDL_WindowSystem::updateEvents() {
@@ -275,18 +275,18 @@ bool OE_SDL_WindowSystem::updateEvents() {
     switch (this->event.type) {
     // check for key presses
     case SDL_KEYDOWN:
-        for (auto key : this->event_handler.input_handler.keyList) {
+        for (auto key : this->event_handler_.input_handler_.keyList_) {
             if (this->event.key.keysym.sym == key.first) {
-                this->event_handler.internalBroadcastKeyDownEvent("keyboard-" + key.second);
+                this->event_handler_.internal_register_keydown_event("keyboard-" + key.second);
             }
         }
         break;
 
     // check for releases
     case SDL_KEYUP:
-        for (auto key : this->event_handler.input_handler.keyList) {
+        for (auto key : this->event_handler_.input_handler_.keyList_) {
             if (this->event.key.keysym.sym == key.first) {
-                this->event_handler.internalBroadcastKeyUpEvent("keyboard-" + key.second);
+                this->event_handler_.internal_register_keyup_event("keyboard-" + key.second);
             }
         }
         break;
@@ -299,18 +299,18 @@ bool OE_SDL_WindowSystem::updateEvents() {
 
         // update mouse down events
     case SDL_MOUSEBUTTONDOWN:
-        for (auto key : this->event_handler.input_handler.mouseList) {
+        for (auto key : this->event_handler_.input_handler_.mouseList_) {
             if (this->event.button.button == key.first) {
-                this->event_handler.internalBroadcastKeyDownEvent("mouse-" + key.second);
+                this->event_handler_.internal_register_keydown_event("mouse-" + key.second);
             }
         }
         break;
 
     // update mouse up events
     case SDL_MOUSEBUTTONUP:
-        for (auto key : this->event_handler.input_handler.mouseList) {
+        for (auto key : this->event_handler_.input_handler_.mouseList_) {
             if (this->event.button.button == key.first) {
-                this->event_handler.internalBroadcastKeyUpEvent("mouse-" + key.second);
+                this->event_handler_.internal_register_keyup_event("mouse-" + key.second);
             }
         }
         break;
@@ -318,12 +318,12 @@ bool OE_SDL_WindowSystem::updateEvents() {
     // update mouse wheel events
     case SDL_MOUSEWHEEL:
 
-        this->event_handler.lockMutex();
+        this->event_handler_.lockMutex();
         // mouse_mouse_wheel = event.wheel.y;
         //  fetch mouse position, since this may be needed
-        this->event_handler.unlockMutex();
+        this->event_handler_.unlockMutex();
 
-        this->event_handler.broadcastIEvent("mouse-wheel");
+        this->event_handler_.broadcast_ievent("mouse-wheel");
         break;
     }
 

--- a/src/winsys_sdl2.cpp
+++ b/src/winsys_sdl2.cpp
@@ -244,15 +244,21 @@ oe::winsys_output OE_SDL_WindowSystem::update(oe::winsys_update_info update_info
     this->counter = this->counter % 100;
 
     SDL_GL_SwapWindow(this->window);
-    // Change viewport resolution if desired
+
+    // change title
+    if (this->title != update_info.title) {
+        this->title = update_info.title;
+        SDL_SetWindowTitle(this->window, this->title.c_str());
+    }
+
+    // Change viewport resolution
     int x;
     int y;
     SDL_GetWindowSize(window, &x, &y);
 
-    lockMutex();
     this->resolution_x = x;
     this->resolution_y = y;
-    unlockMutex();
+
 
     this->event_handler_.update_input();
     this->mouse_moved = false;


### PR DESCRIPTION
## Event Handler

Completely overhauled the event handler by introducing a container for events and storing events by ```size_t``` instead of ```std::string```. Removed unnecessary global/static variables.

## Performance

Significantly improved event handler performance (3x to 5x less CPU usage overall)
Improved overall ```oe::step()``` performance (~25% less CPU usage)
Improved window system update performance due to event handler (~38% less CPU usage overall)
Improved renderer performance on the GPU API (~13% less CPU usage on average)

Measurements made using ```callgrind``` on the default demo with repeatedly pressing keys and moving the mouse all the time for 30 seconds to simulate a real gameplay scenario.

## Configuration

Added configuration ```structs``` in ```dummy_classes.h``` which are managed by the task manager.

All subsystems (physics engine included) now get required initial and runtime configuration options automatically by the task manager through method arguments,
instead of accessing global/static variables directly.

## Renderer

Removed unnecessary global/static variables from the GPU API.

Added ```sanity_checks``` runtime debug option which decreases CPU usage by ~14% if disabled. It is enabled by default for development reasons. If disabled the renderer will just segfault or silently fail upon a runtime error.

## WIndow system

Added API option to change window title on runtime. This was made easy by the configuration options overhaul.
Added API option to request ```OpenGL ES 2.0``` or ```OpenGL ES 3.0``` contexts on Linux at initialisation time instead of the default ```OpenGL 3.3```.

## Conventions

Renamed all classes/methods/members in ```Renderer/DataHandler```, ```Events```, ```Renderer/GL3```, ```Renderer/GLES2``` ,the GPU API and in ```dummy_classes.h```. They now conform to our naming conventions.

## Misc

Enabled C++20 by default which will be a requirement now.

Upon internal exception in the subsystems the engine will now gracefully exit immediately without printing the same error all over again, even if the exception happens in the ```init``` methods.

## FInal thoughts

I want to take a break for a bit to prepare for the new semester, so this will probably be the last pull request before the semester starts.