### PR TITLE
Feature/software renderer

### DIFF
--- a/cross_linux2windows
+++ b/cross_linux2windows
@@ -1,5 +1,4 @@
 meson setup builddir --cross-file mingw_linux.cross
-cp -r cross_config/include subprojects/SDL2-2.0.12/
 meson compile -C builddir
 cp cross_config/libEGL.dll builddir/libEGL.dll
 cp cross_config/libGLESv2.dll builddir/libGLESv2.dll

--- a/cross_linux2windows
+++ b/cross_linux2windows
@@ -1,4 +1,4 @@
-meson builddir --cross-file mingw_linux.cross
+meson setup builddir --cross-file mingw_linux.cross
 cp -r cross_config/include subprojects/SDL2-2.0.12/
 meson compile -C builddir
 cp cross_config/libEGL.dll builddir/libEGL.dll

--- a/emscripten_linux.cross
+++ b/emscripten_linux.cross
@@ -4,9 +4,9 @@ cpp = 'em++'
 ar = 'emar'
 
 [built-in options]
-c_args = ['-Wno-unused-command-line-argument', '-s', 'WASM=1', '-s','EXPORT_ALL=1', '-s', 'USE_SDL=2', '-s', 'MAX_WEBGL_VERSION=2', '-s', 'SINGLE_FILE', '-s', 'FULL_ES3=1','-s', 'NO_DISABLE_EXCEPTION_CATCHING', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'USE_PTHREADS=1']
+c_args = ['-Wno-unused-command-line-argument', '-s', 'WASM=1', '-s','EXPORT_ALL=1', '-s', 'USE_SDL=2', '-s', 'MAX_WEBGL_VERSION=2', '-s', 'SINGLE_FILE', '-s', 'FULL_ES3=1','-s', 'NO_DISABLE_EXCEPTION_CATCHING', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'USE_PTHREADS=1', '-msse', '-msse3', '-msimd128', '-experimental-wasm-simd']
 c_link_args = ['-s','EXPORT_ALL=1', '-s', 'USE_SDL=2', '-s', 'MAX_WEBGL_VERSION=2', '-s', 'SINGLE_FILE', '-s', 'FULL_ES3=1','-s', 'NO_DISABLE_EXCEPTION_CATCHING', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'USE_PTHREADS=1', '--preload-file=../assets@/assets']
-cpp_args = ['-Wno-unused-command-line-argument', '-s', 'WASM=1', '-s','EXPORT_ALL=1', '-s', 'USE_SDL=2', '-s', 'MAX_WEBGL_VERSION=2', '-s', 'SINGLE_FILE', '-s', 'FULL_ES3=1','-s', 'NO_DISABLE_EXCEPTION_CATCHING', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'USE_PTHREADS=1']
+cpp_args = ['-Wno-unused-command-line-argument', '-s', 'WASM=1', '-s','EXPORT_ALL=1', '-s', 'USE_SDL=2', '-s', 'MAX_WEBGL_VERSION=2', '-s', 'SINGLE_FILE', '-s', 'FULL_ES3=1','-s', 'NO_DISABLE_EXCEPTION_CATCHING', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'USE_PTHREADS=1', '-msse', '-msse3', '-msimd128', '-experimental-wasm-simd']
 cpp_link_args = ['-s','EXPORT_ALL=1', '-s', 'USE_SDL=2', '-s', 'MAX_WEBGL_VERSION=2', '-s', 'SINGLE_FILE', '-s', 'FULL_ES3=1','-s', 'NO_DISABLE_EXCEPTION_CATCHING', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'USE_PTHREADS=1', '--preload-file=../assets@/assets']
 
 [host_machine]

--- a/examples/oe_main_test.cpp
+++ b/examples/oe_main_test.cpp
@@ -145,6 +145,9 @@ oe::task_action test_task3(const oe::task_info_t task){
     else if (oe::is_key_just_pressed("keyboard-4")){
         oe::load_world_func("assets/car_gma950.csl", &load_object_handler);
     }
+    else if (oe::is_key_just_pressed("keyboard-5")){
+        oe::load_world_func("assets/OE_VerySimple.csl", &load_object_handler);
+    }
     else {
 
     }
@@ -153,8 +156,8 @@ oe::task_action test_task3(const oe::task_info_t task){
 }
 
 oe::task_action toggle_debug_mode(const oe::task_info_t task){
-    oe::toggle_renderer_sanity_checks();
-    oe::toggle_render_z_prepass();
+    //oe::toggle_renderer_sanity_checks();
+    oe::toggle_software_vertex_shaders();
     return oe::task_action::keep;
 }
 

--- a/include/OE/Carbon/parser.h
+++ b/include/OE/Carbon/parser.h
@@ -378,24 +378,11 @@ namespace csl {
         }
 
         void pass_token() {
-#ifdef __EMSCRIPTEN__
             ++token_it_;
-            while ((*token_it_).type == token_type::whitespace)
-                ++token_it_;
-#else
-            ++token_it_;
-#endif
         }
 
         const std::string_view get_token_content() const {
-#ifdef __EMSCRIPTEN__
-            if ((*token_it_).type == token_type::string)
-                return (*token_it_).content.substr(1, (*token_it_).content.size() - 2);
-            else
-                return (*token_it_).content;
-#else
             return (*token_it_).content;
-#endif
         }
     };
 
@@ -404,10 +391,7 @@ namespace csl {
     inline element parse(std::string& input) {
         lexer_t lexer(input);
 
-#ifdef __EMSCRIPTEN__
-        parser_t parser(lexer.begin(), lexer.end());
-#else
-        constexpr auto is_not_whitespace = [](auto token) { return (token.type != token_type::whitespace); };
+        constexpr auto is_not_whitespace    = [](auto token) { return (token.type != token_type::whitespace); };
         constexpr auto remove_string_quotes = [](auto token) -> decltype(token) {
             if (token.type == token_type::string)
                 return {token_type::string, token.content.substr(1, token.content.size() - 2)};
@@ -415,9 +399,8 @@ namespace csl {
                 return token;
         };
 
-        auto token_range = lexer | std::views::filter(is_not_whitespace) | std::views::transform(remove_string_quotes);
+        auto     token_range = lexer | std::views::filter(is_not_whitespace) | std::views::transform(remove_string_quotes);
         parser_t parser(token_range.begin(), token_range.end());
-#endif
 
         return parser.parse();
     }

--- a/include/OE/Renderer/DataHandler/render_data.h
+++ b/include/OE/Renderer/DataHandler/render_data.h
@@ -86,8 +86,8 @@ namespace nre {
         std::vector<float> get_scaling_min_data();
         std::vector<float> get_scaling_max_data();
 
-        // the mesh is used too fetch vertices only
-        std::shared_ptr<OE_Mesh32> mesh{nullptr};
+        std::vector<float> vbo_data;
+        std::unordered_map<size_t, std::vector<uint32_t>> ibos_data;
 
         std::set<size_t> vgroups;
     };

--- a/include/OE/Renderer/DataHandler/render_data.h
+++ b/include/OE/Renderer/DataHandler/render_data.h
@@ -86,7 +86,7 @@ namespace nre {
         std::vector<float> get_scaling_min_data();
         std::vector<float> get_scaling_max_data();
 
-        std::vector<float> vbo_data;
+        std::vector<float>                                vbo_data;
         std::unordered_map<size_t, std::vector<uint32_t>> ibos_data;
 
         std::set<size_t> vgroups;

--- a/include/OE/Renderer/renderer_legacy.h
+++ b/include/OE/Renderer/renderer_legacy.h
@@ -86,6 +86,7 @@ namespace nre {
         bool                      render_bounding_spheres_{false};
         bool                      use_HDR_{false};
         bool                      use_z_prepass_{false};
+        bool                      use_software_vertex_shaders_{false};
 
         int                    res_x_{0};
         int                    res_y_{0};

--- a/include/OE/Renderer/renderer_legacy.h
+++ b/include/OE/Renderer/renderer_legacy.h
@@ -64,6 +64,7 @@ namespace nre {
         /// These two are in the NRE_RendererUtils.cpp
         void generateDrawCalls();
         void sortPointLights(std::size_t, std::size_t);
+        void update_software_vertex_shaders(size_t, size_t);
         /////////////////////////
 
         void drawRenderGroup(nre::render_group&);

--- a/include/OE/Renderer/shaders_gpu.h
+++ b/include/OE/Renderer/shaders_gpu.h
@@ -10,7 +10,7 @@ namespace nre { namespace gpu {
     // possibility to extend with HLSL/Metal etc.
     enum SHADER_BACKEND : int { UNDEFINED, GL, GLES, GLES2 };
 
-    enum VS_TYPE : uint8_t {
+    enum VS_TYPE {
         VS_UNDEFINED,
         VS_Z_PREPASS,
         VS_REGULAR,
@@ -20,7 +20,7 @@ namespace nre { namespace gpu {
         VS_LIGHT,
     };
 
-    enum FS_TYPE : uint8_t {
+    enum FS_TYPE {
         FS_UNDEFINED,
         FS_SIMPLE,
         FS_GAMMA,

--- a/include/OE/Renderer/shaders_gpu.h
+++ b/include/OE/Renderer/shaders_gpu.h
@@ -14,6 +14,7 @@ namespace nre { namespace gpu {
         VS_UNDEFINED,
         VS_Z_PREPASS,
         VS_REGULAR,
+        VS_REGULAR_SOFTWARE,
         VS_BOUNDING_BOX,
         VS_BOUNDING_SPHERE,
         VS_LIGHT,

--- a/include/OE/api_oe.h
+++ b/include/OE/api_oe.h
@@ -393,6 +393,9 @@ namespace oe {
     void render_HDR(bool);
     void toggle_render_HDR();
 
+    void render_software_vertex_shaders(bool);
+    void toggle_software_vertex_shaders();
+
     void render_z_prepass(bool);
     void toggle_render_z_prepass();
 

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -90,7 +90,7 @@ namespace oe {
      */
     // initial parameters
     struct renderer_init_info {
-        bool use_software_vertex_shaders{false};
+        bool some_var{false};
     };
 
     // dynamic parameters
@@ -101,6 +101,7 @@ namespace oe {
         bool                  render_bounding_boxes{false};
         bool                  render_bounding_spheres{false};
         bool                  use_z_prepass{true};
+        bool                  use_software_vertex_shaders{false};
         RENDERER_SHADING_MODE shading_mode{RENDERER_REGULAR_SHADING};
 
         /// Without sanity checks the renderer may segfault or silently fail without warning or error messages

--- a/include/OE/dummy_classes.h
+++ b/include/OE/dummy_classes.h
@@ -90,7 +90,7 @@ namespace oe {
      */
     // initial parameters
     struct renderer_init_info {
-        bool some_var{false};
+        bool use_software_vertex_shaders{false};
     };
 
     // dynamic parameters

--- a/include/OE/math_oe.h
+++ b/include/OE/math_oe.h
@@ -12,7 +12,7 @@
 #include <glm/vec3.hpp>
 #include <glm/vec4.hpp>
 // #include <glm/gtc/constants.hpp>
-// #include <glm/gtc/type_ptr.hpp>
+#include <glm/gtc/type_ptr.hpp>
 
 // #include <glm/ext/vector_trigonometric.hpp>
 // #include <glm/gtc/matrix_inverse.hpp>
@@ -54,8 +54,9 @@ class OE_Mat4x4 : public glm::mat4 {
 public:
     using glm::mat4::mat4;
 
-    OE_Mat4x4 operator*(const OE_Mat4x4&);
-    OE_Vec4   operator*(const OE_Vec4&);
+    OE_Mat4x4    operator*(const OE_Mat4x4&);
+    OE_Vec4      operator*(const OE_Vec4&);
+    const float* get_ptr();
 };
 
 class OE_Mat3x3 : public glm::mat3 {

--- a/include/OE/math_oe.h
+++ b/include/OE/math_oe.h
@@ -118,7 +118,8 @@ std::vector<float> OE_GetBoundingBoxVertexBuffer(float, float, float, float, flo
 std::vector<float>    OE_GetBoundingSphereVertexBuffer(float, float, size_t);
 std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float, float, size_t);
 namespace oe { namespace math {
-        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, const std::vector<uint32_t>&, OE_Mat4x4,
-                                                    OE_Mat4x4, int);
+        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, OE_Mat4x4, OE_Mat4x4, int);
+        std::vector<float> vertex_shader_regular_sw_ibo(const std::vector<float>&, const std::vector<uint32_t>&, OE_Mat4x4,
+                                                        OE_Mat4x4, int);
 }; };  // namespace oe::math
 #endif // FMATH_H_INCLUDED

--- a/include/OE/math_oe.h
+++ b/include/OE/math_oe.h
@@ -117,7 +117,6 @@ std::vector<float> OE_GetBoundingBoxVertexBuffer(float, float, float, float, flo
 std::vector<float>    OE_GetBoundingSphereVertexBuffer(float, float, size_t);
 std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float, float, size_t);
 namespace oe { namespace math {
-        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, const std::vector<float>&,
-                                                    const std::vector<float>&, int);
+        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, OE_Mat4x4, OE_Mat4x4, int);
 }; };  // namespace oe::math
 #endif // FMATH_H_INCLUDED

--- a/include/OE/math_oe.h
+++ b/include/OE/math_oe.h
@@ -118,6 +118,6 @@ std::vector<float> OE_GetBoundingBoxVertexBuffer(float, float, float, float, flo
 std::vector<float>    OE_GetBoundingSphereVertexBuffer(float, float, size_t);
 std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float, float, size_t);
 namespace oe { namespace math {
-        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, OE_Mat4x4, OE_Mat4x4, int);
+        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, const std::vector<uint32_t>&, OE_Mat4x4, OE_Mat4x4, int);
 }; };  // namespace oe::math
 #endif // FMATH_H_INCLUDED

--- a/include/OE/math_oe.h
+++ b/include/OE/math_oe.h
@@ -87,9 +87,9 @@ public:
 #define OE_Dot          glm::dot
 
 #define OE_Identity     glm::identity
-#define OE_Det          glm::determinant
-#define OE_Transpose    glm::transpose*/
+#define OE_Det          glm::determinant*/
 
+OE_Mat4x4 OE_Transpose(OE_Mat4x4);
 OE_Mat4x4 OE_Translate(OE_Mat4x4, OE_Vec3);
 OE_Mat4x4 OE_Scale(OE_Mat4x4, OE_Vec3);
 
@@ -116,5 +116,8 @@ std::vector<float> OE_GetBoundingBoxVertexBuffer(float, float, float, float, flo
 
 std::vector<float>    OE_GetBoundingSphereVertexBuffer(float, float, size_t);
 std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float, float, size_t);
-
+namespace oe { namespace math {
+        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, const std::vector<float>&,
+                                                    const std::vector<float>&, int);
+}; };  // namespace oe::math
 #endif // FMATH_H_INCLUDED

--- a/include/OE/math_oe.h
+++ b/include/OE/math_oe.h
@@ -118,6 +118,7 @@ std::vector<float> OE_GetBoundingBoxVertexBuffer(float, float, float, float, flo
 std::vector<float>    OE_GetBoundingSphereVertexBuffer(float, float, size_t);
 std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float, float, size_t);
 namespace oe { namespace math {
-        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, const std::vector<uint32_t>&, OE_Mat4x4, OE_Mat4x4, int);
+        std::vector<float> vertex_shader_regular_sw(const std::vector<float>&, const std::vector<uint32_t>&, OE_Mat4x4,
+                                                    OE_Mat4x4, int);
 }; };  // namespace oe::math
 #endif // FMATH_H_INCLUDED

--- a/meson.build
+++ b/meson.build
@@ -47,10 +47,6 @@ src = ['src/Renderer/glad.c',
 internal_inc = include_directories('./include') 
 
 
-if meson.get_compiler('c', native : false).get_id() != 'emscripten'
-    add_global_arguments('-msse3', language : 'cpp')
-endif
-
 # external dependencies
 cmake = import('cmake')
 sub_proj = cmake.subproject('ctre')

--- a/meson.build
+++ b/meson.build
@@ -47,9 +47,11 @@ src = ['src/Renderer/glad.c',
 internal_inc = include_directories('./include') 
 
 
+if meson.get_compiler('c', native : false).get_id() != 'emscripten'
+    add_global_arguments('-msse3', language : 'cpp')
+endif
+
 # external dependencies
-
-
 cmake = import('cmake')
 sub_proj = cmake.subproject('ctre')
 ctre_dep = sub_proj.dependency('ctre')

--- a/src/Events/input_event_handler.cpp
+++ b/src/Events/input_event_handler.cpp
@@ -9,7 +9,7 @@ oe::input_event_handler_t::input_event_handler_t() {
         {SDL_BUTTON_LEFT, "1"}, {SDL_BUTTON_RIGHT, "2"}, {SDL_BUTTON_MIDDLE, "3"}, {SDL_BUTTON_X1, "4"}, {SDL_BUTTON_X2, "5"}};
     keyList_ = {
         {SDLK_0, "0"},         {SDLK_1, "1"},           {SDLK_2, "2"},           {SDLK_3, "3"},         {SDLK_4, "4"},
-        {SDLK_5, "0"},         {SDLK_6, "6"},           {SDLK_7, "7"},           {SDLK_8, "8"},         {SDLK_9, "9"},
+        {SDLK_5, "5"},         {SDLK_6, "6"},           {SDLK_7, "7"},           {SDLK_8, "8"},         {SDLK_9, "9"},
         {SDLK_a, "a"},         {SDLK_b, "b"},           {SDLK_c, "c"},           {SDLK_d, "d"},         {SDLK_e, "e"},
         {SDLK_f, "f"},         {SDLK_g, "g"},           {SDLK_h, "h"},           {SDLK_i, "i"},         {SDLK_j, "j"},
         {SDLK_k, "k"},         {SDLK_l, "l"},           {SDLK_m, "m"},           {SDLK_n, "n"},         {SDLK_o, "o"},

--- a/src/Renderer/DataHandler/data_handler.cpp
+++ b/src/Renderer/DataHandler/data_handler.cpp
@@ -151,7 +151,7 @@ void nre::data_handler_t::handle_mesh_data(std::size_t id, std::shared_ptr<OE_Me
         mesh->data->vbo_mutex.unlockMutex();
 
         mesh->data->ibos_mutex.lockMutex();
-        for (auto vg : this->meshes_[id].vgroups){
+        for (auto vg : this->meshes_[id].vgroups) {
             this->meshes_[id].ibos_data[vg] = std::move(mesh->data->ibos[vg].data);
         }
         mesh->data->ibos_mutex.unlockMutex();

--- a/src/Renderer/DataHandler/data_handler.cpp
+++ b/src/Renderer/DataHandler/data_handler.cpp
@@ -139,9 +139,22 @@ void nre::data_handler_t::handle_mesh_data(std::size_t id, std::shared_ptr<OE_Me
         this->meshes_[id].uvmaps = mesh->data->vertices.uvmaps.size();
         this->meshes_[id].size   = mesh->data->vbo.size();
 
-        // store the shared pointer
-        this->meshes_[id].mesh = mesh;
+        // handle Vertex (Triangle) groups
+        for (auto vgroup : mesh->data->triangle_groups) {
+            this->handle_vgroup_data(id, vgroup.first, mesh);
+            this->meshes_[id].vgroups.insert(vgroup.first);
+        }
 
+        // store mesh vbo and index buffers
+        mesh->data->vbo_mutex.lockMutex();
+        this->meshes_[id].vbo_data = std::move(mesh->data->vbo);
+        mesh->data->vbo_mutex.unlockMutex();
+
+        mesh->data->ibos_mutex.lockMutex();
+        for (auto vg : this->meshes_[id].vgroups){
+            this->meshes_[id].ibos_data[vg] = std::move(mesh->data->ibos[vg].data);
+        }
+        mesh->data->ibos_mutex.unlockMutex();
         // setup the Uniform buffer holding the model matrix
         //  but offload the actual OpenGL commands for later, since this runs in a performance
         //  critical section
@@ -150,12 +163,6 @@ void nre::data_handler_t::handle_mesh_data(std::size_t id, std::shared_ptr<OE_Me
 
         // this->meshes_[id].data = OE_Mat4x4ToSTDVector(model_mat);
         this->meshes_[id].changed = true;
-
-        // handle Vertex (Triangle) groups
-        for (auto vgroup : mesh->data->triangle_groups) {
-            this->handle_vgroup_data(id, vgroup.first, mesh);
-            this->meshes_[id].vgroups.insert(vgroup.first);
-        }
 
         // store bounding box
 

--- a/src/Renderer/GLES2/api_gles2.cpp
+++ b/src/Renderer/GLES2/api_gles2.cpp
@@ -1148,9 +1148,16 @@ void nre::gles2::api_t::setup_program(std::size_t id) {
 
     if (not(this->progs_[id].vs.fullscreenQuad or (this->progs_[id].vs.type == nre::gpu::VS_Z_PREPASS))) {
         glBindAttribLocation(this->progs_[id].handle, 1, "oe_normals");
+
+        int offset = 2;
+        if (this->progs_[id].vs.type == nre::gpu::VS_REGULAR_SOFTWARE) {
+            glBindAttribLocation(this->progs_[id].handle, 2, "oe_position_clip");
+            offset = offset + 1;
+        }
+
         for (size_t i = 0; i < this->progs_[id].vs.num_of_uvs; i++) {
             std::string attrib_name = "oe_uvs" + to_string(i);
-            glBindAttribLocation(this->progs_[id].handle, i + 2, attrib_name.c_str());
+            glBindAttribLocation(this->progs_[id].handle, i + offset, attrib_name.c_str());
         }
     }
 

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -354,11 +354,9 @@ void nre::renderer_legacy_t::drawRenderGroup(nre::render_group& ren_group) {
         nre::gpu::set_program_uniform_data(ren_group.program, "MVP_Matrix", OE_Mat4x4ToSTDVector(mvp_mat));
     }
     else {
-        auto mvp_mat_tr       = OE_Transpose(mvp_mat);
-        auto model_mat_tr     = OE_Transpose(model_mat);
-        auto updated_vertices = oe::math::vertex_shader_regular_sw(data_.meshes_[ren_group.mesh].vbo_data, model_mat_tr,
-                                                                   mvp_mat_tr, data_.meshes_[ren_group.mesh].uvmaps);
-        nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[ren_group.mesh].vbo, updated_vertices, nre::gpu::DYNAMIC);
+        auto updated_vertices = oe::math::vertex_shader_regular_sw(data_.meshes_[ren_group.mesh].vbo_data, model_mat, mvp_mat,
+                                                                   data_.meshes_[ren_group.mesh].uvmaps);
+        nre::gpu::set_vertex_buf_data(data_.meshes_[ren_group.mesh].vbo, updated_vertices, 0);
     }
 
 
@@ -496,9 +494,16 @@ void nre::renderer_legacy_t::updateMeshGPUData() {
         if (!data_.meshes_[mesh.first].vao_initialized) {
 
             /// vertex buffer
-            if (!this->use_software_vertex_shaders_)
+            if (!this->use_software_vertex_shaders_) {
                 nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[mesh.first].vbo, data_.meshes_[mesh.first].vbo_data,
                                                          nre::gpu::STATIC);
+            }
+            else {
+                long int offset          = 6 + data_.meshes_[mesh.first].uvmaps * 2;
+                long int num_of_vertices = data_.meshes_[mesh.first].vbo_data.size() / offset;
+                nre::gpu::set_vertex_buf_memory(data_.meshes_[mesh.first].vbo, num_of_vertices * (offset + 4),
+                                                nre::gpu::STREAM);
+            }
 
             /// index buffers
             for (auto vg : mesh.second.vgroups) {

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -476,28 +476,19 @@ void nre::renderer_legacy_t::updateMeshGPUData() {
         if (!data_.meshes_[mesh.first].vao_initialized) {
 
             /// vertex buffer
-            data_.meshes_[mesh.first].mesh->data->vbo_mutex.lockMutex();
-            nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[mesh.first].vbo, data_.meshes_[mesh.first].mesh->data->vbo,
+            nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[mesh.first].vbo, data_.meshes_[mesh.first].vbo_data,
                                                      nre::gpu::STATIC);
-            data_.meshes_[mesh.first].mesh->data->vbo.clear();
-            data_.meshes_[mesh.first].mesh->data->vbo_mutex.unlockMutex();
-
 
             /// index buffers
-            data_.meshes_[mesh.first].mesh->data->ibos_mutex.lockMutex();
             for (auto vg : mesh.second.vgroups) {
                 data_.vgroups_[vg].ibo = nre::gpu::new_index_buf();
                 nre::gpu::set_index_buf_memory_and_data(data_.vgroups_[vg].ibo,
-                                                        data_.meshes_[mesh.first].mesh->data->ibos[vg].data, nre::gpu::STATIC);
-                data_.meshes_[mesh.first].mesh->data->ibos[vg].data.clear();
+                                                        data_.meshes_[mesh.first].ibos_data[vg], nre::gpu::STATIC);
             }
-
-            data_.meshes_[mesh.first].mesh->data->ibos_mutex.unlockMutex();
 
             /// vertex layout
             typedef nre::gpu::vertex_layout_input VLI; // for clarity
 
-            data_.meshes_[mesh.first].mesh->data->ibos.clear();
             // delete data_.meshes_[mesh.first].mesh->data->index_buffer;
             // data_.meshes_[mesh.first].mesh->data->index_buffer = nullptr;
 

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -354,9 +354,9 @@ void nre::renderer_legacy_t::drawRenderGroup(nre::render_group& ren_group) {
         nre::gpu::set_program_uniform_data(ren_group.program, "MVP_Matrix", OE_Mat4x4ToSTDVector(mvp_mat));
     }
     else {
-        auto updated_vertices = oe::math::vertex_shader_regular_sw(data_.meshes_[ren_group.mesh].vbo_data, model_mat, mvp_mat,
+        auto updated_vertices = oe::math::vertex_shader_regular_sw(data_.meshes_[ren_group.mesh].vbo_data, data_.meshes_[ren_group.mesh].ibos_data[ren_group.vgroup], model_mat, mvp_mat,
                                                                    data_.meshes_[ren_group.mesh].uvmaps);
-        nre::gpu::set_vertex_buf_data(data_.meshes_[ren_group.mesh].vbo, updated_vertices, 0);
+        nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[ren_group.mesh].vbo, updated_vertices, nre::gpu::STREAM);
     }
 
 
@@ -372,7 +372,13 @@ void nre::renderer_legacy_t::drawRenderGroup(nre::render_group& ren_group) {
         nre::gpu::set_program_uniform_data(ren_group.program, "mat_specular_hardness",
                                            data_.materials_[ren_group.material].get_mat_specular_hardness());
     }
-    nre::gpu::draw(ren_group.program, data_.meshes_[ren_group.mesh].vao, data_.vgroups_[ren_group.vgroup].ibo);
+
+    if (not this->use_software_vertex_shaders_) {
+        nre::gpu::draw(ren_group.program, data_.meshes_[ren_group.mesh].vao, data_.vgroups_[ren_group.vgroup].ibo);
+    }
+    else{
+        nre::gpu::draw(ren_group.program, data_.meshes_[ren_group.mesh].vao);
+    }
 }
 
 void nre::renderer_legacy_t::drawRenderGroupZPrePass(nre::render_group& ren_group) {

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -354,8 +354,8 @@ void nre::renderer_legacy_t::drawRenderGroup(nre::render_group& ren_group) {
         nre::gpu::set_program_uniform_data(ren_group.program, "MVP_Matrix", OE_Mat4x4ToSTDVector(mvp_mat));
     }
     else {
-        auto mvp_mat_tr       = OE_Mat4x4ToSTDVector(OE_Transpose(mvp_mat));
-        auto model_mat_tr     = OE_Mat4x4ToSTDVector(OE_Transpose(model_mat));
+        auto mvp_mat_tr       = OE_Transpose(mvp_mat);
+        auto model_mat_tr     = OE_Transpose(model_mat);
         auto updated_vertices = oe::math::vertex_shader_regular_sw(data_.meshes_[ren_group.mesh].vbo_data, model_mat_tr,
                                                                    mvp_mat_tr, data_.meshes_[ren_group.mesh].uvmaps);
         nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[ren_group.mesh].vbo, updated_vertices, nre::gpu::DYNAMIC);

--- a/src/Renderer/renderer_legacy.cpp
+++ b/src/Renderer/renderer_legacy.cpp
@@ -354,8 +354,9 @@ void nre::renderer_legacy_t::drawRenderGroup(nre::render_group& ren_group) {
         nre::gpu::set_program_uniform_data(ren_group.program, "MVP_Matrix", OE_Mat4x4ToSTDVector(mvp_mat));
     }
     else {
-        auto updated_vertices = oe::math::vertex_shader_regular_sw(data_.meshes_[ren_group.mesh].vbo_data, data_.meshes_[ren_group.mesh].ibos_data[ren_group.vgroup], model_mat, mvp_mat,
-                                                                   data_.meshes_[ren_group.mesh].uvmaps);
+        auto updated_vertices = oe::math::vertex_shader_regular_sw(data_.meshes_[ren_group.mesh].vbo_data,
+                                                                   data_.meshes_[ren_group.mesh].ibos_data[ren_group.vgroup],
+                                                                   model_mat, mvp_mat, data_.meshes_[ren_group.mesh].uvmaps);
         nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[ren_group.mesh].vbo, updated_vertices, nre::gpu::STREAM);
     }
 
@@ -376,7 +377,7 @@ void nre::renderer_legacy_t::drawRenderGroup(nre::render_group& ren_group) {
     if (not this->use_software_vertex_shaders_) {
         nre::gpu::draw(ren_group.program, data_.meshes_[ren_group.mesh].vao, data_.vgroups_[ren_group.vgroup].ibo);
     }
-    else{
+    else {
         nre::gpu::draw(ren_group.program, data_.meshes_[ren_group.mesh].vao);
     }
 }

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -515,8 +515,8 @@ void nre::renderer_t::updateMeshGPUData() {
             /// index buffers
             for (auto vg : mesh.second.vgroups) {
                 data_.vgroups_[vg].ibo = nre::gpu::new_index_buf();
-                nre::gpu::set_index_buf_memory_and_data(data_.vgroups_[vg].ibo,
-                                                        data_.meshes_[mesh.first].ibos_data[vg], nre::gpu::STATIC);
+                nre::gpu::set_index_buf_memory_and_data(data_.vgroups_[vg].ibo, data_.meshes_[mesh.first].ibos_data[vg],
+                                                        nre::gpu::STATIC);
             }
 
             /// vertex layout

--- a/src/Renderer/renderer_main.cpp
+++ b/src/Renderer/renderer_main.cpp
@@ -509,28 +509,19 @@ void nre::renderer_t::updateMeshGPUData() {
         if (!data_.meshes_[mesh.first].vao_initialized) {
 
             /// vertex buffer
-            data_.meshes_[mesh.first].mesh->data->vbo_mutex.lockMutex();
-            nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[mesh.first].vbo, data_.meshes_[mesh.first].mesh->data->vbo,
+            nre::gpu::set_vertex_buf_memory_and_data(data_.meshes_[mesh.first].vbo, data_.meshes_[mesh.first].vbo_data,
                                                      nre::gpu::STATIC);
-            data_.meshes_[mesh.first].mesh->data->vbo.clear();
-            data_.meshes_[mesh.first].mesh->data->vbo_mutex.unlockMutex();
-
 
             /// index buffers
-            data_.meshes_[mesh.first].mesh->data->ibos_mutex.lockMutex();
             for (auto vg : mesh.second.vgroups) {
                 data_.vgroups_[vg].ibo = nre::gpu::new_index_buf();
                 nre::gpu::set_index_buf_memory_and_data(data_.vgroups_[vg].ibo,
-                                                        data_.meshes_[mesh.first].mesh->data->ibos[vg].data, nre::gpu::STATIC);
-                data_.meshes_[mesh.first].mesh->data->ibos[vg].data.clear();
+                                                        data_.meshes_[mesh.first].ibos_data[vg], nre::gpu::STATIC);
             }
-
-            data_.meshes_[mesh.first].mesh->data->ibos_mutex.unlockMutex();
 
             /// vertex layout
             typedef nre::gpu::vertex_layout_input VLI; // for clarity
 
-            data_.meshes_[mesh.first].mesh->data->ibos.clear();
             // delete data_.meshes_[mesh.first].mesh->data->index_buffer;
             // data_.meshes_[mesh.first].mesh->data->index_buffer = nullptr;
 

--- a/src/Renderer/shaders_gpu.cpp
+++ b/src/Renderer/shaders_gpu.cpp
@@ -93,6 +93,9 @@ std::string nre::gpu::vertex_shader_t::info() const {
     case VS_REGULAR:
         ss << "VS_REGULAR";
         break;
+    case VS_REGULAR_SOFTWARE:
+        ss << "VS_REGULAR_SOFTWARE";
+        break;
     case VS_BOUNDING_BOX:
         ss << "VS_BOUNDING_BOX";
         break;

--- a/src/api_oe.cpp
+++ b/src/api_oe.cpp
@@ -491,6 +491,22 @@ void oe::toggle_render_HDR() {
     OE_Main->renderer_mutex_.unlockMutex();
 }
 
+void oe::render_software_vertex_shaders(bool value) {
+    OE_API_Helpers::checkIfInit();
+    OE_Main->renderer_mutex_.lockMutex();
+    OE_Main->renderer_info_.use_software_vertex_shaders = value;
+    OE_Main->renderer_mutex_.unlockMutex();
+}
+void oe::toggle_software_vertex_shaders() {
+    OE_API_Helpers::checkIfInit();
+    OE_Main->renderer_mutex_.lockMutex();
+    if (OE_Main->renderer_info_.use_software_vertex_shaders)
+        OE_Main->renderer_info_.use_software_vertex_shaders = false;
+    else
+        OE_Main->renderer_info_.use_software_vertex_shaders = true;
+    OE_Main->renderer_mutex_.unlockMutex();
+}
+
 void oe::render_z_prepass(bool value) {
     OE_API_Helpers::checkIfInit();
     OE_Main->renderer_mutex_.lockMutex();

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -470,8 +470,8 @@ std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float r1, float r2, size_t
     return ibo;
 }
 
-std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, const std::vector<uint32_t>& ibo,
-                                                      OE_Mat4x4 model_matrix_in, OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
+std::vector<float> oe::math::vertex_shader_regular_sw_ibo(const std::vector<float>& vbo, const std::vector<uint32_t>& ibo,
+                                                          OE_Mat4x4 model_matrix_in, OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
 
     /* This overly complicated function basically accelerates the 3 matrix-vector multiplications
      * which are normally done inside the vertex shader.
@@ -512,8 +512,6 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
 
     for (long int i = 0; i < num_of_vertices; i++) {
 
-
-
         __m128 vertex_x = _mm_set1_ps(bufptr[ibo[i] * offset]);
         __m128 vertex_y = _mm_set1_ps(bufptr[ibo[i] * offset + 1]);
         __m128 vertex_z = _mm_set1_ps(bufptr[ibo[i] * offset + 2]);
@@ -552,6 +550,117 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
 
         for (int uv = 0; uv < num_of_uvs; uv++) {
             std::memcpy(&output[i * (offset + 4) + 10 + uv * 2], &bufptr[ibo[i] * offset + 6 + uv * 2], 8);
+        }
+    }
+
+#else
+
+    for (long int i = 0; i < num_of_vertices; i++) {
+        OE_Vec4 vertex = OE_Vec4(bufptr[ibo[i] * offset], bufptr[ibo[i] * offset + 1], bufptr[ibo[i] * offset + 2], 1.0f);
+        OE_Vec4 normal = OE_Vec4(bufptr[ibo[i] * offset + 3], bufptr[ibo[i] * offset + 4], bufptr[ibo[i] * offset + 5], 0.0f);
+
+        OE_Vec4 vertex_transformed = model_matrix_in * vertex;
+        OE_Vec4 normal_transformed = model_matrix_in * normal;
+        OE_Vec4 vertex_everything  = mvp_matrix_in * vertex;
+
+
+        for (int coord = 0; coord < 3; coord++) {
+            output[i * (offset + 4) + coord]     = vertex_transformed[coord];
+            output[i * (offset + 4) + coord + 3] = normal_transformed[coord];
+            output[i * (offset + 4) + coord + 6] = vertex_everything[coord];
+        }
+
+        output[i * (offset + 4) + 9] = vertex_everything[3];
+
+        for (int uv = 0; uv < num_of_uvs; uv++) {
+            std::memcpy(&output[i * (offset + 4) + 10 + uv * 2], &bufptr[ibo[i] * offset + 6 + uv * 2], 8);
+        }
+    }
+
+#endif
+    return output;
+}
+
+std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, OE_Mat4x4 model_matrix_in,
+                                                      OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
+
+    /* This overly complicated function basically accelerates the 3 matrix-vector multiplications
+     * which are normally done inside the vertex shader.
+     *
+     * Why is it needed? Because for my highly performant 1-core Intel Atom netbook, there also exists an integrated "GPU".
+     * This integrated GPU (GMA 3150) also known as GMD (Graphics Media DECELERATOR) does not
+     * support hardware-accelerated vertex shaders, which means they have to run on the CPU.
+     *
+     * Apparently, running the calculations here manually provides visible performance increase (~30%+) against
+     * a vertex shader compiled by mesa for some reason.
+     *
+     * Also this is a first step towards purely software rendering.
+     */
+
+    auto         bufsize = vbo.size();
+    const float* bufptr  = &vbo[0];
+
+    const long int offset          = 6 + num_of_uvs * 2;
+    const long int num_of_vertices = bufsize / offset;
+
+    std::vector<float> output;
+    output.reserve(num_of_vertices * (offset + 4));
+    output.resize(num_of_vertices * (offset + 4));
+
+#ifndef OE_USE_NO_SSE_FALLBACK
+    const float* model_matrix = model_matrix_in.get_ptr();
+    const float* mvp_matrix   = mvp_matrix_in.get_ptr();
+
+    __m128 model_mat_1 = _mm_loadu_ps(&model_matrix[0]);
+    __m128 model_mat_2 = _mm_loadu_ps(&model_matrix[4]);
+    __m128 model_mat_3 = _mm_loadu_ps(&model_matrix[8]);
+    __m128 model_mat_4 = _mm_loadu_ps(&model_matrix[12]);
+
+    __m128 mvp_mat_1 = _mm_loadu_ps(&mvp_matrix[0]);
+    __m128 mvp_mat_2 = _mm_loadu_ps(&mvp_matrix[4]);
+    __m128 mvp_mat_3 = _mm_loadu_ps(&mvp_matrix[8]);
+    __m128 mvp_mat_4 = _mm_loadu_ps(&mvp_matrix[12]);
+
+    for (long int i = 0; i < num_of_vertices; i++) {
+
+        __m128 vertex_x = _mm_set1_ps(bufptr[i * offset]);
+        __m128 vertex_y = _mm_set1_ps(bufptr[i * offset + 1]);
+        __m128 vertex_z = _mm_set1_ps(bufptr[i * offset + 2]);
+
+        __m128 normal_x = _mm_set1_ps(bufptr[i * offset + 3]);
+        __m128 normal_y = _mm_set1_ps(bufptr[i * offset + 4]);
+        __m128 normal_z = _mm_set1_ps(bufptr[i * offset + 5]);
+
+        __m128 mm_x = _mm_mul_ps(vertex_x, model_mat_1);
+        __m128 mm_y = _mm_mul_ps(vertex_y, model_mat_2);
+        __m128 mm_z = _mm_mul_ps(vertex_z, model_mat_3);
+
+        __m128 mm_xy  = _mm_add_ps(mm_x, mm_y);
+        __m128 mm_zw  = _mm_add_ps(mm_z, model_mat_4);
+        __m128 mm1234 = _mm_add_ps(mm_xy, mm_zw);
+        _mm_storeu_ps(&output[i * (offset + 4)], mm1234);
+
+        __m128 mmn_x = _mm_mul_ps(normal_x, model_mat_1);
+        __m128 mmn_y = _mm_mul_ps(normal_y, model_mat_2);
+        __m128 mmn_z = _mm_mul_ps(normal_z, model_mat_3);
+
+        __m128 mmn_xy  = _mm_add_ps(mmn_x, mmn_y);
+        __m128 mmn1234 = _mm_add_ps(mmn_xy, mmn_z);
+
+        _mm_storeu_ps(&output[i * (offset + 4) + 3], mmn1234);
+
+        __m128 mvp1 = _mm_mul_ps(vertex_x, mvp_mat_1);
+        __m128 mvp2 = _mm_mul_ps(vertex_y, mvp_mat_2);
+        __m128 mvp3 = _mm_mul_ps(vertex_z, mvp_mat_3);
+
+        __m128 mvp12   = _mm_add_ps(mvp1, mvp2);
+        __m128 mvp34   = _mm_add_ps(mvp3, mvp_mat_4);
+        __m128 mvp1234 = _mm_add_ps(mvp12, mvp34);
+
+        _mm_storeu_ps(&output[i * (offset + 4) + 6], mvp1234);
+
+        for (int uv = 0; uv < num_of_uvs; uv++) {
+            std::memcpy(&output[i * (offset + 4) + 10 + uv * 2], &bufptr[i * offset + 6 + uv * 2], 8);
         }
     }
 

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -519,6 +519,11 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
         __m128 vertex_in  = _mm_load_ps(&vertices[0]);
         __m128 normals_in = _mm_load_ps(&normals[0]);
 
+        // explanation: "mm1" stands for "model matrix 1st row dot product with vertices"
+        // explanation: "mmn1" stands for "model matrix 1st row dot product with normals"
+        // explanation: "mvp1" stands for "mvp (ModelViewPerspective) matrix 1st row dot product with vertices"
+        // equivalent for the rest
+
         __m128 mm1  = _mm_mul_ps(vertex_in, model_mat_1);
         __m128 mmn1 = _mm_mul_ps(normals_in, model_mat_1);
         __m128 mvp1 = _mm_mul_ps(vertex_in, mvp_mat_1);

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -489,8 +489,8 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
     auto         bufsize = vbo.size();
     const float* bufptr  = &vbo[0];
 
-    long int offset          = 6 + num_of_uvs * 2;
-    long int num_of_vertices = bufsize / offset;
+    const long int offset          = 6 + num_of_uvs * 2;
+    const long int num_of_vertices = bufsize / offset;
 
     std::vector<float> output;
     output.reserve(num_of_vertices * (offset + 4));
@@ -500,70 +500,53 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
     const float* model_matrix = model_matrix_in.get_ptr();
     const float* mvp_matrix   = mvp_matrix_in.get_ptr();
 
-    __m128 model_mat_1 = _mm_setr_ps(model_matrix[0], model_matrix[4], model_matrix[8], model_matrix[12]);
-    __m128 model_mat_2 = _mm_setr_ps(model_matrix[1], model_matrix[5], model_matrix[9], model_matrix[13]);
-    __m128 model_mat_3 = _mm_setr_ps(model_matrix[2], model_matrix[6], model_matrix[10], model_matrix[14]);
-    __m128 model_mat_4 = _mm_setr_ps(model_matrix[3], model_matrix[7], model_matrix[11], model_matrix[15]);
+    __m128 model_mat_1 = _mm_loadu_ps(&model_matrix[0]);
+    __m128 model_mat_2 = _mm_loadu_ps(&model_matrix[4]);
+    __m128 model_mat_3 = _mm_loadu_ps(&model_matrix[8]);
+    __m128 model_mat_4 = _mm_loadu_ps(&model_matrix[12]);
 
-    __m128 mvp_mat_1 = _mm_setr_ps(mvp_matrix[0], mvp_matrix[4], mvp_matrix[8], mvp_matrix[12]);
-    __m128 mvp_mat_2 = _mm_setr_ps(mvp_matrix[1], mvp_matrix[5], mvp_matrix[9], mvp_matrix[13]);
-    __m128 mvp_mat_3 = _mm_setr_ps(mvp_matrix[2], mvp_matrix[6], mvp_matrix[10], mvp_matrix[14]);
-    __m128 mvp_mat_4 = _mm_setr_ps(mvp_matrix[3], mvp_matrix[7], mvp_matrix[11], mvp_matrix[15]);
-
-    __m128 empty_buf = _mm_set_ps(0.0f, 0.0f, 0.0f, 0.0f);
+    __m128 mvp_mat_1 = _mm_loadu_ps(&mvp_matrix[0]);
+    __m128 mvp_mat_2 = _mm_loadu_ps(&mvp_matrix[4]);
+    __m128 mvp_mat_3 = _mm_loadu_ps(&mvp_matrix[8]);
+    __m128 mvp_mat_4 = _mm_loadu_ps(&mvp_matrix[12]);
 
     for (long int i = 0; i < num_of_vertices; i++) {
 
-        alignas(16) float vertices[4];
-        alignas(16) float normals[4];
+        __m128 vertex_x = _mm_set1_ps(bufptr[i*offset]);
+        __m128 vertex_y = _mm_set1_ps(bufptr[i*offset+1]);
+        __m128 vertex_z = _mm_set1_ps(bufptr[i*offset+2]);
 
-        vertices[3] = 1.0f;
-        normals[3]  = 0.0f;
+        __m128 normal_x = _mm_set1_ps(bufptr[i*offset+3]);
+        __m128 normal_y = _mm_set1_ps(bufptr[i*offset+4]);
+        __m128 normal_z = _mm_set1_ps(bufptr[i*offset+5]);
 
-        std::memcpy(&vertices[0], &bufptr[i * offset], 12);
-        std::memcpy(&normals[0], &bufptr[i * offset + 3], 12);
+        __m128 mm_x = _mm_mul_ps(vertex_x, model_mat_1);
+         __m128 mm_y = _mm_mul_ps(vertex_y, model_mat_2);
+         __m128 mm_z = _mm_mul_ps(vertex_z, model_mat_3);
 
-        __m128 vertex_in  = _mm_load_ps(&vertices[0]);
-        __m128 normals_in = _mm_load_ps(&normals[0]);
+        __m128 mm_xy = _mm_add_ps(mm_x, mm_y);
+        __m128 mm_zw = _mm_add_ps(mm_z, model_mat_4);
+        __m128 mm1234 = _mm_add_ps(mm_xy, mm_zw);
+        _mm_storeu_ps(&output[i*(offset+4)], mm1234);
 
-        // explanation: "mm1" stands for "model matrix 1st row dot product with vertices"
-        // explanation: "mmn1" stands for "model matrix 1st row dot product with normals"
-        // explanation: "mvp1" stands for "mvp (ModelViewPerspective) matrix 1st row dot product with vertices"
-        // equivalent for the rest
+        __m128 mmn_x = _mm_mul_ps(normal_x, model_mat_1);
+         __m128 mmn_y = _mm_mul_ps(normal_y, model_mat_2);
+         __m128 mmn_z = _mm_mul_ps(normal_z, model_mat_3);
 
-        __m128 mm1  = _mm_mul_ps(vertex_in, model_mat_1);
-        __m128 mmn1 = _mm_mul_ps(normals_in, model_mat_1);
-        __m128 mvp1 = _mm_mul_ps(vertex_in, mvp_mat_1);
+        __m128 mmn_xy = _mm_add_ps(mmn_x, mmn_y);
+        __m128 mmn1234 = _mm_add_ps(mmn_xy, mmn_z);
 
-        __m128 mm2  = _mm_mul_ps(vertex_in, model_mat_2);
-        __m128 mmn2 = _mm_mul_ps(normals_in, model_mat_2);
-        __m128 mvp2 = _mm_mul_ps(vertex_in, mvp_mat_2);
+        _mm_storeu_ps(&output[i*(offset+4)+3], mmn1234);
 
-        __m128 mm3  = _mm_mul_ps(vertex_in, model_mat_3);
-        __m128 mmn3 = _mm_mul_ps(normals_in, model_mat_3);
-        __m128 mvp3 = _mm_mul_ps(vertex_in, mvp_mat_3);
+        __m128 mvp1 = _mm_mul_ps(vertex_x, mvp_mat_1);
+        __m128 mvp2 = _mm_mul_ps(vertex_y, mvp_mat_2);
+        __m128 mvp3 = _mm_mul_ps(vertex_z, mvp_mat_3);
 
-        __m128 mm4  = _mm_mul_ps(vertex_in, model_mat_4);
-        __m128 mvp4 = _mm_mul_ps(vertex_in, mvp_mat_4);
+        __m128 mvp12 = _mm_add_ps(mvp1, mvp2);
+        __m128 mvp34 = _mm_add_ps(mvp3, mvp_mat_4);
+        __m128 mvp1234 = _mm_add_ps(mvp12, mvp34);
 
-        __m128 mm12  = _mm_hadd_ps(mm1, mm2);
-        __m128 mvp12 = _mm_hadd_ps(mvp1, mvp2);
-        __m128 mmn12 = _mm_hadd_ps(mmn1, mmn2);
-
-        __m128 mm34  = _mm_hadd_ps(mm3, mm4);
-        __m128 mvp34 = _mm_hadd_ps(mvp3, mvp4);
-        __m128 mmn34 = _mm_hadd_ps(mmn3, empty_buf);
-
-        __m128 mmn1234 = _mm_hadd_ps(mmn12, mmn34);
-        __m128 mm1234  = _mm_hadd_ps(mm12, mm34);
-        __m128 mvp1234 = _mm_hadd_ps(mvp12, mvp34);
-
-        _mm_store_ps(&normals[0], mmn1234);
-        _mm_store_ps(&vertices[0], mm1234);
-        _mm_storeu_ps(&output[i * (offset + 4) + 6], mvp1234);
-
-        std::memcpy(&output[i * (offset + 4)], &vertices[0], 12);
-        std::memcpy(&output[i * (offset + 4) + 3], &normals[0], 12);
+        _mm_storeu_ps(&output[i*(offset+4)+6], mvp1234);
 
         for (int uv = 0; uv < num_of_uvs; uv++) {
             std::memcpy(&output[i * (offset + 4) + 10 + uv * 2], &bufptr[i * offset + 6 + uv * 2], 8);

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -470,7 +470,7 @@ std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float r1, float r2, size_t
     return ibo;
 }
 
-std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, OE_Mat4x4 model_matrix_in,
+std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, const std::vector<uint32_t>& ibo, OE_Mat4x4 model_matrix_in,
                                                       OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
 
     /* This overly complicated function basically accelerates the 3 matrix-vector multiplications
@@ -490,7 +490,7 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
     const float* bufptr  = &vbo[0];
 
     const long int offset          = 6 + num_of_uvs * 2;
-    const long int num_of_vertices = bufsize / offset;
+    const long int num_of_vertices = ibo.size();
 
     std::vector<float> output;
     output.reserve(num_of_vertices * (offset + 4));
@@ -512,13 +512,13 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
 
     for (long int i = 0; i < num_of_vertices; i++) {
 
-        __m128 vertex_x = _mm_set1_ps(bufptr[i * offset]);
-        __m128 vertex_y = _mm_set1_ps(bufptr[i * offset + 1]);
-        __m128 vertex_z = _mm_set1_ps(bufptr[i * offset + 2]);
+        __m128 vertex_x = _mm_set1_ps(bufptr[ibo[i] * offset]);
+        __m128 vertex_y = _mm_set1_ps(bufptr[ibo[i] * offset + 1]);
+        __m128 vertex_z = _mm_set1_ps(bufptr[ibo[i] * offset + 2]);
 
-        __m128 normal_x = _mm_set1_ps(bufptr[i * offset + 3]);
-        __m128 normal_y = _mm_set1_ps(bufptr[i * offset + 4]);
-        __m128 normal_z = _mm_set1_ps(bufptr[i * offset + 5]);
+        __m128 normal_x = _mm_set1_ps(bufptr[ibo[i] * offset + 3]);
+        __m128 normal_y = _mm_set1_ps(bufptr[ibo[i] * offset + 4]);
+        __m128 normal_z = _mm_set1_ps(bufptr[ibo[i] * offset + 5]);
 
         __m128 mm_x = _mm_mul_ps(vertex_x, model_mat_1);
         __m128 mm_y = _mm_mul_ps(vertex_y, model_mat_2);

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -512,41 +512,41 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
 
     for (long int i = 0; i < num_of_vertices; i++) {
 
-        __m128 vertex_x = _mm_set1_ps(bufptr[i*offset]);
-        __m128 vertex_y = _mm_set1_ps(bufptr[i*offset+1]);
-        __m128 vertex_z = _mm_set1_ps(bufptr[i*offset+2]);
+        __m128 vertex_x = _mm_set1_ps(bufptr[i * offset]);
+        __m128 vertex_y = _mm_set1_ps(bufptr[i * offset + 1]);
+        __m128 vertex_z = _mm_set1_ps(bufptr[i * offset + 2]);
 
-        __m128 normal_x = _mm_set1_ps(bufptr[i*offset+3]);
-        __m128 normal_y = _mm_set1_ps(bufptr[i*offset+4]);
-        __m128 normal_z = _mm_set1_ps(bufptr[i*offset+5]);
+        __m128 normal_x = _mm_set1_ps(bufptr[i * offset + 3]);
+        __m128 normal_y = _mm_set1_ps(bufptr[i * offset + 4]);
+        __m128 normal_z = _mm_set1_ps(bufptr[i * offset + 5]);
 
         __m128 mm_x = _mm_mul_ps(vertex_x, model_mat_1);
-         __m128 mm_y = _mm_mul_ps(vertex_y, model_mat_2);
-         __m128 mm_z = _mm_mul_ps(vertex_z, model_mat_3);
+        __m128 mm_y = _mm_mul_ps(vertex_y, model_mat_2);
+        __m128 mm_z = _mm_mul_ps(vertex_z, model_mat_3);
 
-        __m128 mm_xy = _mm_add_ps(mm_x, mm_y);
-        __m128 mm_zw = _mm_add_ps(mm_z, model_mat_4);
+        __m128 mm_xy  = _mm_add_ps(mm_x, mm_y);
+        __m128 mm_zw  = _mm_add_ps(mm_z, model_mat_4);
         __m128 mm1234 = _mm_add_ps(mm_xy, mm_zw);
-        _mm_storeu_ps(&output[i*(offset+4)], mm1234);
+        _mm_storeu_ps(&output[i * (offset + 4)], mm1234);
 
         __m128 mmn_x = _mm_mul_ps(normal_x, model_mat_1);
-         __m128 mmn_y = _mm_mul_ps(normal_y, model_mat_2);
-         __m128 mmn_z = _mm_mul_ps(normal_z, model_mat_3);
+        __m128 mmn_y = _mm_mul_ps(normal_y, model_mat_2);
+        __m128 mmn_z = _mm_mul_ps(normal_z, model_mat_3);
 
-        __m128 mmn_xy = _mm_add_ps(mmn_x, mmn_y);
+        __m128 mmn_xy  = _mm_add_ps(mmn_x, mmn_y);
         __m128 mmn1234 = _mm_add_ps(mmn_xy, mmn_z);
 
-        _mm_storeu_ps(&output[i*(offset+4)+3], mmn1234);
+        _mm_storeu_ps(&output[i * (offset + 4) + 3], mmn1234);
 
         __m128 mvp1 = _mm_mul_ps(vertex_x, mvp_mat_1);
         __m128 mvp2 = _mm_mul_ps(vertex_y, mvp_mat_2);
         __m128 mvp3 = _mm_mul_ps(vertex_z, mvp_mat_3);
 
-        __m128 mvp12 = _mm_add_ps(mvp1, mvp2);
-        __m128 mvp34 = _mm_add_ps(mvp3, mvp_mat_4);
+        __m128 mvp12   = _mm_add_ps(mvp1, mvp2);
+        __m128 mvp34   = _mm_add_ps(mvp3, mvp_mat_4);
         __m128 mvp1234 = _mm_add_ps(mvp12, mvp34);
 
-        _mm_storeu_ps(&output[i*(offset+4)+6], mvp1234);
+        _mm_storeu_ps(&output[i * (offset + 4) + 6], mvp1234);
 
         for (int uv = 0; uv < num_of_uvs; uv++) {
             std::memcpy(&output[i * (offset + 4) + 10 + uv * 2], &bufptr[i * offset + 6 + uv * 2], 8);

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -470,8 +470,8 @@ std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float r1, float r2, size_t
     return ibo;
 }
 
-std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, const std::vector<uint32_t>& ibo, OE_Mat4x4 model_matrix_in,
-                                                      OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
+std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, const std::vector<uint32_t>& ibo,
+                                                      OE_Mat4x4 model_matrix_in, OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
 
     /* This overly complicated function basically accelerates the 3 matrix-vector multiplications
      * which are normally done inside the vertex shader.
@@ -512,6 +512,8 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
 
     for (long int i = 0; i < num_of_vertices; i++) {
 
+
+
         __m128 vertex_x = _mm_set1_ps(bufptr[ibo[i] * offset]);
         __m128 vertex_y = _mm_set1_ps(bufptr[ibo[i] * offset + 1]);
         __m128 vertex_z = _mm_set1_ps(bufptr[ibo[i] * offset + 2]);
@@ -549,7 +551,7 @@ std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& 
         _mm_storeu_ps(&output[i * (offset + 4) + 6], mvp1234);
 
         for (int uv = 0; uv < num_of_uvs; uv++) {
-            std::memcpy(&output[i * (offset + 4) + 10 + uv * 2], &bufptr[i * offset + 6 + uv * 2], 8);
+            std::memcpy(&output[i * (offset + 4) + 10 + uv * 2], &bufptr[ibo[i] * offset + 6 + uv * 2], 8);
         }
     }
 

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -468,6 +468,18 @@ std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float r1, float r2, size_t
 std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, OE_Mat4x4 model_matrix_in,
                                                       OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
 
+    /* This overly complicated function basically accelerates the 3 matrix-vector multiplications
+     * which are normally done inside the vertex shader.
+     *
+     * Why is it needed? Because for my highly performant 1-core Intel Atom netbook, there also exists an integrated "GPU".
+     * This integrated GPU (GMA 3150) also known as GMD (Graphics Media DECELERATOR) does not
+     * support hardware-accelerated vertex shaders, which means they have to run on the CPU.
+     *
+     * Apparently, running the calculations here manually provides visible performance increase (~30%+) against
+     * a vertex shader compiled by mesa for some reason.
+     *
+     * Also this is a first step towards purely software rendering.
+     */
     auto         bufsize = vbo.size();
     const float* bufptr  = &vbo[0];
 

--- a/src/math_oe.cpp
+++ b/src/math_oe.cpp
@@ -1,10 +1,16 @@
 #include <OE/math_oe.h>
+
+#include <pmmintrin.h>
+#include <xmmintrin.h>
+
 #include <glm/ext/matrix_float4x4.hpp>
 #include <glm/ext/matrix_transform.hpp>
 #include <glm/gtc/constants.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/quaternion.hpp>
 #include <iostream>
+
+
 
 using namespace std;
 
@@ -459,11 +465,14 @@ std::vector<uint32_t> OE_GetBoundingSphereIndexBuffer(float r1, float r2, size_t
     return ibo;
 }
 
-std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, const std::vector<float>& model_matrix,
-                                                      const std::vector<float>& mvp_matrix, int num_of_uvs) {
-#include <immintrin.h>
+std::vector<float> oe::math::vertex_shader_regular_sw(const std::vector<float>& vbo, OE_Mat4x4 model_matrix_in,
+                                                      OE_Mat4x4 mvp_matrix_in, int num_of_uvs) {
+
     auto         bufsize = vbo.size();
     const float* bufptr  = &vbo[0];
+
+    auto model_matrix = OE_Mat4x4ToSTDVector(model_matrix_in);
+    auto mvp_matrix   = OE_Mat4x4ToSTDVector(mvp_matrix_in);
 
     __m128 model_mat_1 = _mm_setr_ps(model_matrix[0], model_matrix[1], model_matrix[2], model_matrix[3]);
     __m128 model_mat_2 = _mm_setr_ps(model_matrix[4], model_matrix[5], model_matrix[6], model_matrix[7]);


### PR DESCRIPTION
- Completed basic software vertex shader implementation for OpenGL ES 2 (only in ```nre::renderer_legacy_t```)
- Added API to request this software vertex shader implementation on runtime.
- Fixed some compiler errors with newer g++.
- Removed ```emscripten```-specific```#ifdef```s from the the parser, since ```emscripten``` now supports C++20 ranges normally.
- Updated SDL2 version for the windows cross-compilation.

You may ask why a software vertex shader? Well because the Intel GMA 3150 on my old crappy netbook cannot do vertex shaders, that's why. And it would be even faster if MESA didn't bottleneck it by even the most basic vertex shader, which just copies everything around. Overall only a ~30% performance increase on the netbook.